### PR TITLE
Create new combination classes for conventional age vs F14C date reporting

### DIFF
--- a/src/c14/datamodel/c14.py
+++ b/src/c14/datamodel/c14.py
@@ -1,5 +1,5 @@
 # Auto generated from c14.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-01-13T13:45:16
+# Generation date: 2026-01-14T16:41:35
 # Schema: miaard
 #
 # id: https://w3id.org/MIxS-MInAS/miaard
@@ -89,8 +89,6 @@ class RadiocarbonDate(YAMLRoot):
 
     lab_code: Union[str, "LabCode"] = None
     lab_id: str = None
-    conventional_age: float = None
-    conventional_age_error: float = None
     f14c: float = None
     f14c_error: float = None
     sample_ids: Union[str, list[str]] = None
@@ -105,8 +103,8 @@ class RadiocarbonDate(YAMLRoot):
     pretreatment_yield: float = None
     carbon_proportion: float = None
     suspected_reservoir_effect: Union[bool, Bool] = None
-    carbon_nitro_ratio: float = None
-    recrystalisation: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
     delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
     sample_taxon_scientific_name: Optional[str] = None
     sample_anatomical_part: Optional[str] = None
@@ -120,10 +118,6 @@ class RadiocarbonDate(YAMLRoot):
     delta_13_c: Optional[float] = None
     delta_13_c_error: Optional[float] = None
     delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    delta_15_n: Optional[float] = None
-    delta_15_n_error: Optional[float] = None
-    delta_34_s: Optional[float] = None
-    delta_34_s_error: Optional[float] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
         if self._is_empty(self.lab_code):
@@ -135,16 +129,6 @@ class RadiocarbonDate(YAMLRoot):
             self.MissingRequiredField("lab_id")
         if not isinstance(self.lab_id, str):
             self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.conventional_age):
-            self.MissingRequiredField("conventional_age")
-        if not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self._is_empty(self.conventional_age_error):
-            self.MissingRequiredField("conventional_age_error")
-        if not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
 
         if self._is_empty(self.f14c):
             self.MissingRequiredField("f14c")
@@ -220,15 +204,11 @@ class RadiocarbonDate(YAMLRoot):
         if not isinstance(self.suspected_reservoir_effect, Bool):
             self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
 
-        if self._is_empty(self.carbon_nitro_ratio):
-            self.MissingRequiredField("carbon_nitro_ratio")
-        if not isinstance(self.carbon_nitro_ratio, float):
-            self.carbon_nitro_ratio = float(self.carbon_nitro_ratio)
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
 
-        if self._is_empty(self.recrystalisation):
-            self.MissingRequiredField("recrystalisation")
-        if not isinstance(self.recrystalisation, Bool):
-            self.recrystalisation = Bool(self.recrystalisation)
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
 
         if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
             self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
@@ -269,18 +249,6 @@ class RadiocarbonDate(YAMLRoot):
         if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
             self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
 
-        if self.delta_15_n is not None and not isinstance(self.delta_15_n, float):
-            self.delta_15_n = float(self.delta_15_n)
-
-        if self.delta_15_n_error is not None and not isinstance(self.delta_15_n_error, float):
-            self.delta_15_n_error = float(self.delta_15_n_error)
-
-        if self.delta_34_s is not None and not isinstance(self.delta_34_s, float):
-            self.delta_34_s = float(self.delta_34_s)
-
-        if self.delta_34_s_error is not None and not isinstance(self.delta_34_s_error, float):
-            self.delta_34_s_error = float(self.delta_34_s_error)
-
         super().__post_init__(**kwargs)
 
 
@@ -302,6 +270,1156 @@ class RadiocarbonDateCollection(YAMLRoot):
         if not isinstance(self.entries, list):
             self.entries = [self.entries] if self.entries is not None else []
         self.entries = [v if isinstance(v, RadiocarbonDate) else RadiocarbonDate(**as_dict(v)) for v in self.entries]
+
+        super().__post_init__(**kwargs)
+
+
+class Extension(YAMLRoot):
+    """
+    A collection of recommended metadata terms for a specific context
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["Extension"]
+    class_class_curie: ClassVar[str] = "c14:Extension"
+    class_name: ClassVar[str] = "Extension"
+    class_model_uri: ClassVar[URIRef] = C14.Extension
+
+
+@dataclass(repr=False)
+class ProteinaceousSample(Extension):
+    """
+    Terms specific to proteinaceous samples being dated
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["ProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:ProteinaceousSample"
+    class_name: ClassVar[str] = "ProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.ProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    delta_15_n: Optional[float] = None
+    delta_15_n_error: Optional[float] = None
+    delta_34_s: Optional[float] = None
+    delta_34_s_error: Optional[float] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.carbon_nitro_ratio):
+            self.MissingRequiredField("carbon_nitro_ratio")
+        if not isinstance(self.carbon_nitro_ratio, float):
+            self.carbon_nitro_ratio = float(self.carbon_nitro_ratio)
+
+        if self.delta_15_n is not None and not isinstance(self.delta_15_n, float):
+            self.delta_15_n = float(self.delta_15_n)
+
+        if self.delta_15_n_error is not None and not isinstance(self.delta_15_n_error, float):
+            self.delta_15_n_error = float(self.delta_15_n_error)
+
+        if self.delta_34_s is not None and not isinstance(self.delta_34_s, float):
+            self.delta_34_s = float(self.delta_34_s)
+
+        if self.delta_34_s_error is not None and not isinstance(self.delta_34_s_error, float):
+            self.delta_34_s_error = float(self.delta_34_s_error)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class CarbonateSample(Extension):
+    """
+    Terms specific to carbonate samples being dated
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["CarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:CarbonateSample"
+    class_name: ClassVar[str] = "CarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.CarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.recrystalisation):
+            self.MissingRequiredField("recrystalisation")
+        if not isinstance(self.recrystalisation, Bool):
+            self.recrystalisation = Bool(self.recrystalisation)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
+    """
+    A radiocarbon determination on a proteinaceous sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["RadiocarbonDateProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:RadiocarbonDateProteinaceousSample"
+    class_name: ClassVar[str] = "RadiocarbonDateProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.RadiocarbonDateProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class RadiocarbonDateCarbonateSample(CarbonateSample):
+    """
+    A radiocarbon determination on a carbonate sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["RadiocarbonDateCarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:RadiocarbonDateCarbonateSample"
+    class_name: ClassVar[str] = "RadiocarbonDateCarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.RadiocarbonDateCarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample):
+    """
+    F14C value radiocarbon date of a proteinaceous sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateProteinaceousSample"
+    class_name: ClassVar[str] = "F14CRadiocarbonDateProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class F14CRadiocarbonDateCarbonateSample(CarbonateSample):
+    """
+    F14C value radiocarbon date of a carbonate sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateCarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateCarbonateSample"
+    class_name: ClassVar[str] = "F14CRadiocarbonDateCarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateCarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample):
+    """
+    Conventional age radiocarbon date of a proteinaceous sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["ConventionalAgeRadiocarbonDateProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:ConventionalAgeRadiocarbonDateProteinaceousSample"
+    class_name: ClassVar[str] = "ConventionalAgeRadiocarbonDateProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.ConventionalAgeRadiocarbonDateProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    conventional_age: float = None
+    conventional_age_error: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.conventional_age):
+            self.MissingRequiredField("conventional_age")
+        if not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self._is_empty(self.conventional_age_error):
+            self.MissingRequiredField("conventional_age_error")
+        if not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample):
+    """
+    Conventional age radiocarbon date of a carbonate sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["ConventionalAgeRadiocarbonDateCarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:ConventionalAgeRadiocarbonDateCarbonateSample"
+    class_name: ClassVar[str] = "ConventionalAgeRadiocarbonDateCarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.ConventionalAgeRadiocarbonDateCarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+    conventional_age: float = None
+    conventional_age_error: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_percentage_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.conventional_age):
+            self.MissingRequiredField("conventional_age")
+        if not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self._is_empty(self.conventional_age_error):
+            self.MissingRequiredField("conventional_age_error")
+        if not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
+            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
 
         super().__post_init__(**kwargs)
 
@@ -1638,10 +2756,10 @@ slots.lab_id = Slot(uri=C14['000002'], name="lab_id", curie=C14.curie('000002'),
                    model_uri=C14.lab_id, domain=None, range=str)
 
 slots.conventional_age = Slot(uri=C14['000005'], name="conventional_age", curie=C14.curie('000005'),
-                   model_uri=C14.conventional_age, domain=None, range=float)
+                   model_uri=C14.conventional_age, domain=None, range=Optional[float])
 
 slots.conventional_age_error = Slot(uri=C14['000006'], name="conventional_age_error", curie=C14.curie('000006'),
-                   model_uri=C14.conventional_age_error, domain=None, range=float)
+                   model_uri=C14.conventional_age_error, domain=None, range=Optional[float])
 
 slots.f14c = Slot(uri=C14['000003'], name="f14c", curie=C14.curie('000003'),
                    model_uri=C14.f14c, domain=None, range=float)
@@ -1656,10 +2774,12 @@ slots.sample_ids = Slot(uri=C14['000008'], name="sample_ids", curie=C14.curie('0
                    model_uri=C14.sample_ids, domain=None, range=Union[str, list[str]])
 
 slots.sample_material = Slot(uri=C14['000009'], name="sample_material", curie=C14.curie('000009'),
-                   model_uri=C14.sample_material, domain=None, range=str)
+                   model_uri=C14.sample_material, domain=None, range=str,
+                   pattern=re.compile(r'[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'))
 
 slots.sample_taxon_id = Slot(uri=C14['000010'], name="sample_taxon_id", curie=C14.curie('000010'),
-                   model_uri=C14.sample_taxon_id, domain=None, range=Union[str, list[str]])
+                   model_uri=C14.sample_taxon_id, domain=None, range=Union[str, list[str]],
+                   pattern=re.compile(r'[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'))
 
 slots.sample_taxon_id_confidence = Slot(uri=C14['000011'], name="sample_taxon_id_confidence", curie=C14.curie('000011'),
                    model_uri=C14.sample_taxon_id_confidence, domain=None, range=Union[bool, Bool])
@@ -1668,7 +2788,8 @@ slots.sample_taxon_scientific_name = Slot(uri=C14['000012'], name="sample_taxon_
                    model_uri=C14.sample_taxon_scientific_name, domain=None, range=Optional[str])
 
 slots.sample_anatomical_part = Slot(uri=C14['000013'], name="sample_anatomical_part", curie=C14.curie('000013'),
-                   model_uri=C14.sample_anatomical_part, domain=None, range=Optional[str])
+                   model_uri=C14.sample_anatomical_part, domain=None, range=Optional[str],
+                   pattern=re.compile(r'[a-zA-Z]{2,}:[a-zA-Z0-9]\d+'))
 
 slots.suspected_sample_contamination = Slot(uri=C14['000014'], name="suspected_sample_contamination", curie=C14.curie('000014'),
                    model_uri=C14.suspected_sample_contamination, domain=None, range=Optional[Union[bool, Bool]])
@@ -1695,7 +2816,8 @@ slots.pretreatment_method_description = Slot(uri=C14['000021'], name="pretreatme
                    model_uri=C14.pretreatment_method_description, domain=None, range=str)
 
 slots.pretreatment_method_protocol = Slot(uri=C14['000022'], name="pretreatment_method_protocol", curie=C14.curie('000022'),
-                   model_uri=C14.pretreatment_method_protocol, domain=None, range=Union[str, list[str]])
+                   model_uri=C14.pretreatment_method_protocol, domain=None, range=Union[str, list[str]],
+                   pattern=re.compile(r'^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$'))
 
 slots.measurement_method = Slot(uri=C14['000023'], name="measurement_method", curie=C14.curie('000023'),
                    model_uri=C14.measurement_method, domain=None, range=Union[str, "RadiocarbonMeasurementMethod"])
@@ -1744,3 +2866,15 @@ slots.recrystalisation = Slot(uri=C14['000037'], name="recrystalisation", curie=
 
 slots.radiocarbonDateCollection__entries = Slot(uri=C14.entries, name="radiocarbonDateCollection__entries", curie=C14.curie('entries'),
                    model_uri=C14.radiocarbonDateCollection__entries, domain=None, range=Optional[Union[Union[dict, RadiocarbonDate], list[Union[dict, RadiocarbonDate]]]])
+
+slots.ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age = Slot(uri=C14['000005'], name="ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age", curie=C14.curie('000005'),
+                   model_uri=C14.ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age, domain=ConventionalAgeRadiocarbonDateProteinaceousSample, range=float)
+
+slots.ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age_error = Slot(uri=C14['000006'], name="ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age_error", curie=C14.curie('000006'),
+                   model_uri=C14.ConventionalAgeRadiocarbonDateProteinaceousSample_conventional_age_error, domain=ConventionalAgeRadiocarbonDateProteinaceousSample, range=float)
+
+slots.ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age = Slot(uri=C14['000005'], name="ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age", curie=C14.curie('000005'),
+                   model_uri=C14.ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age, domain=ConventionalAgeRadiocarbonDateCarbonateSample, range=float)
+
+slots.ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age_error = Slot(uri=C14['000006'], name="ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age_error", curie=C14.curie('000006'),
+                   model_uri=C14.ConventionalAgeRadiocarbonDateCarbonateSample_conventional_age_error, domain=ConventionalAgeRadiocarbonDateCarbonateSample, range=float)

--- a/src/c14/datamodel/c14.py
+++ b/src/c14/datamodel/c14.py
@@ -1,5 +1,5 @@
 # Auto generated from c14.yaml by pythongen.py version: 0.0.1
-# Generation date: 2026-01-14T16:41:35
+# Generation date: 2026-01-19T10:25:35
 # Schema: miaard
 #
 # id: https://w3id.org/miaard/miaard-schema
@@ -210,6 +210,141 @@ class RadiocarbonDate(YAMLRoot):
         if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
             self.conventional_age_error = float(self.conventional_age_error)
 
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_proportion_yield is not None and not isinstance(self.pretreatment_proportion_yield, float):
+            self.pretreatment_proportion_yield = float(self.pretreatment_proportion_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class RadiocarbonDateCollection(YAMLRoot):
+    """
+    A collection of radiocarbon determinations with associated metadata.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["RadiocarbonDateCollection"]
+    class_class_curie: ClassVar[str] = "c14:RadiocarbonDateCollection"
+    class_name: ClassVar[str] = "RadiocarbonDateCollection"
+    class_model_uri: ClassVar[URIRef] = C14.RadiocarbonDateCollection
+
+    entries: Optional[Union[Union[dict, RadiocarbonDate], list[Union[dict, RadiocarbonDate]]]] = empty_list()
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if not isinstance(self.entries, list):
+            self.entries = [self.entries] if self.entries is not None else []
+        self.entries = [v if isinstance(v, RadiocarbonDate) else RadiocarbonDate(**as_dict(v)) for v in self.entries]
+
+        super().__post_init__(**kwargs)
+
+
+class Extension(YAMLRoot):
+    """
+    A collection of recommended metadata terms for a specific context.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["Extension"]
+    class_class_curie: ClassVar[str] = "c14:Extension"
+    class_name: ClassVar[str] = "Extension"
+    class_model_uri: ClassVar[URIRef] = C14.Extension
+
+
+@dataclass(repr=False)
+class ProteinaceousSample(Extension):
+    """
+    Terms specific to proteinaceous samples being dated.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["ProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:ProteinaceousSample"
+    class_name: ClassVar[str] = "ProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.ProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    delta_15_n: Optional[float] = None
+    delta_15_n_error: Optional[float] = None
+    delta_34_s: Optional[float] = None
+    delta_34_s_error: Optional[float] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.carbon_nitro_ratio):
+            self.MissingRequiredField("carbon_nitro_ratio")
+        if not isinstance(self.carbon_nitro_ratio, float):
+            self.carbon_nitro_ratio = float(self.carbon_nitro_ratio)
+
+        if self.delta_15_n is not None and not isinstance(self.delta_15_n, float):
+            self.delta_15_n = float(self.delta_15_n)
+
+        if self.delta_15_n_error is not None and not isinstance(self.delta_15_n_error, float):
+            self.delta_15_n_error = float(self.delta_15_n_error)
+
+        if self.delta_34_s is not None and not isinstance(self.delta_34_s, float):
+            self.delta_34_s = float(self.delta_34_s)
+
+        if self.delta_34_s_error is not None and not isinstance(self.delta_34_s_error, float):
+            self.delta_34_s_error = float(self.delta_34_s_error)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class CarbonateSample(Extension):
+    """
+    Terms specific to carbonate samples being dated.
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["CarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:CarbonateSample"
+    class_name: ClassVar[str] = "CarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.CarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.recrystalisation):
+            self.MissingRequiredField("recrystalisation")
+        if not isinstance(self.recrystalisation, Bool):
+            self.recrystalisation = Bool(self.recrystalisation)
+
         super().__post_init__(**kwargs)
 
 
@@ -228,8 +363,6 @@ class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
     carbon_nitro_ratio: float = None
     lab_code: Union[str, "LabCode"] = None
     lab_id: str = None
-    conventional_age: float = None
-    conventional_age_error: float = None
     f14c: float = None
     f14c_error: float = None
     sample_ids: Union[str, list[str]] = None
@@ -244,6 +377,8 @@ class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
     pretreatment_yield: float = None
     carbon_proportion: float = None
     suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
     delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
     sample_taxon_scientific_name: Optional[str] = None
     sample_anatomical_part: Optional[str] = None
@@ -268,16 +403,6 @@ class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
             self.MissingRequiredField("lab_id")
         if not isinstance(self.lab_id, str):
             self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.conventional_age):
-            self.MissingRequiredField("conventional_age")
-        if not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self._is_empty(self.conventional_age_error):
-            self.MissingRequiredField("conventional_age_error")
-        if not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
 
         if self._is_empty(self.f14c):
             self.MissingRequiredField("f14c")
@@ -352,6 +477,12 @@ class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
             self.MissingRequiredField("suspected_reservoir_effect")
         if not isinstance(self.suspected_reservoir_effect, Bool):
             self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
 
         if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
             self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
@@ -410,8 +541,542 @@ class RadiocarbonDateCarbonateSample(CarbonateSample):
     recrystalisation: Union[bool, Bool] = None
     lab_code: Union[str, "LabCode"] = None
     lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_proportion_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_proportion_yield is not None and not isinstance(self.pretreatment_proportion_yield, float):
+            self.pretreatment_proportion_yield = float(self.pretreatment_proportion_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample):
+    """
+    F14C value radiocarbon date of a proteinaceous sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateProteinaceousSample"
+    class_name: ClassVar[str] = "F14CRadiocarbonDateProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateProteinaceousSample
+
+    carbon_nitro_ratio: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_proportion_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_proportion_yield is not None and not isinstance(self.pretreatment_proportion_yield, float):
+            self.pretreatment_proportion_yield = float(self.pretreatment_proportion_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class F14CRadiocarbonDateCarbonateSample(CarbonateSample):
+    """
+    F14C value radiocarbon date of a carbonate sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateCarbonateSample"]
+    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateCarbonateSample"
+    class_name: ClassVar[str] = "F14CRadiocarbonDateCarbonateSample"
+    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateCarbonateSample
+
+    recrystalisation: Union[bool, Bool] = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
+    f14c: float = None
+    f14c_error: float = None
+    sample_ids: Union[str, list[str]] = None
+    sample_material: str = None
+    sample_taxon_id: Union[str, list[str]] = None
+    sample_taxon_id_confidence: Union[bool, Bool] = None
+    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
+    pretreatment_method_description: str = None
+    pretreatment_method_protocol: Union[str, list[str]] = None
+    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
+    sample_starting_weight: float = None
+    pretreatment_yield: float = None
+    carbon_proportion: float = None
+    suspected_reservoir_effect: Union[bool, Bool] = None
+    conventional_age: Optional[float] = None
+    conventional_age_error: Optional[float] = None
+    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+    sample_taxon_scientific_name: Optional[str] = None
+    sample_anatomical_part: Optional[str] = None
+    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
+    suspected_sample_contamination_description: Optional[str] = None
+    sample_location: Optional[str] = None
+    decimal_latitude: Optional[float] = None
+    decimal_longitude: Optional[float] = None
+    coordinate_precision: Optional[float] = None
+    pretreatment_proportion_yield: Optional[float] = None
+    delta_13_c: Optional[float] = None
+    delta_13_c_error: Optional[float] = None
+    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
+
+    def __post_init__(self, *_: str, **kwargs: Any):
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
+
+        if self._is_empty(self.f14c):
+            self.MissingRequiredField("f14c")
+        if not isinstance(self.f14c, float):
+            self.f14c = float(self.f14c)
+
+        if self._is_empty(self.f14c_error):
+            self.MissingRequiredField("f14c_error")
+        if not isinstance(self.f14c_error, float):
+            self.f14c_error = float(self.f14c_error)
+
+        if self._is_empty(self.sample_ids):
+            self.MissingRequiredField("sample_ids")
+        if not isinstance(self.sample_ids, list):
+            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
+        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
+
+        if self._is_empty(self.sample_material):
+            self.MissingRequiredField("sample_material")
+        if not isinstance(self.sample_material, str):
+            self.sample_material = str(self.sample_material)
+
+        if self._is_empty(self.sample_taxon_id):
+            self.MissingRequiredField("sample_taxon_id")
+        if not isinstance(self.sample_taxon_id, list):
+            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
+        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
+
+        if self._is_empty(self.sample_taxon_id_confidence):
+            self.MissingRequiredField("sample_taxon_id_confidence")
+        if not isinstance(self.sample_taxon_id_confidence, Bool):
+            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
+
+        if self._is_empty(self.pretreatment_methods):
+            self.MissingRequiredField("pretreatment_methods")
+        if not isinstance(self.pretreatment_methods, list):
+            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
+        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
+
+        if self._is_empty(self.pretreatment_method_description):
+            self.MissingRequiredField("pretreatment_method_description")
+        if not isinstance(self.pretreatment_method_description, str):
+            self.pretreatment_method_description = str(self.pretreatment_method_description)
+
+        if self._is_empty(self.pretreatment_method_protocol):
+            self.MissingRequiredField("pretreatment_method_protocol")
+        if not isinstance(self.pretreatment_method_protocol, list):
+            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
+        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
+
+        if self._is_empty(self.measurement_method):
+            self.MissingRequiredField("measurement_method")
+        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
+            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
+
+        if self._is_empty(self.sample_starting_weight):
+            self.MissingRequiredField("sample_starting_weight")
+        if not isinstance(self.sample_starting_weight, float):
+            self.sample_starting_weight = float(self.sample_starting_weight)
+
+        if self._is_empty(self.pretreatment_yield):
+            self.MissingRequiredField("pretreatment_yield")
+        if not isinstance(self.pretreatment_yield, float):
+            self.pretreatment_yield = float(self.pretreatment_yield)
+
+        if self._is_empty(self.carbon_proportion):
+            self.MissingRequiredField("carbon_proportion")
+        if not isinstance(self.carbon_proportion, float):
+            self.carbon_proportion = float(self.carbon_proportion)
+
+        if self._is_empty(self.suspected_reservoir_effect):
+            self.MissingRequiredField("suspected_reservoir_effect")
+        if not isinstance(self.suspected_reservoir_effect, Bool):
+            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
+
+        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
+            self.conventional_age = float(self.conventional_age)
+
+        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
+            self.conventional_age_error = float(self.conventional_age_error)
+
+        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
+            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
+
+        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
+            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
+
+        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
+            self.sample_anatomical_part = str(self.sample_anatomical_part)
+
+        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
+            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
+
+        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
+            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
+
+        if self.sample_location is not None and not isinstance(self.sample_location, str):
+            self.sample_location = str(self.sample_location)
+
+        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
+            self.decimal_latitude = float(self.decimal_latitude)
+
+        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
+            self.decimal_longitude = float(self.decimal_longitude)
+
+        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
+            self.coordinate_precision = float(self.coordinate_precision)
+
+        if self.pretreatment_proportion_yield is not None and not isinstance(self.pretreatment_proportion_yield, float):
+            self.pretreatment_proportion_yield = float(self.pretreatment_proportion_yield)
+
+        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
+            self.delta_13_c = float(self.delta_13_c)
+
+        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
+            self.delta_13_c_error = float(self.delta_13_c_error)
+
+        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
+            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass(repr=False)
+class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample):
+    """
+    Conventional age radiocarbon date of a proteinaceous sample
+    """
+    _inherited_slots: ClassVar[list[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = C14["ConventionalAgeRadiocarbonDateProteinaceousSample"]
+    class_class_curie: ClassVar[str] = "c14:ConventionalAgeRadiocarbonDateProteinaceousSample"
+    class_name: ClassVar[str] = "ConventionalAgeRadiocarbonDateProteinaceousSample"
+    class_model_uri: ClassVar[URIRef] = C14.ConventionalAgeRadiocarbonDateProteinaceousSample
+
+    carbon_nitro_ratio: float = None
     conventional_age: float = None
     conventional_age_error: float = None
+    lab_code: Union[str, "LabCode"] = None
+    lab_id: str = None
     f14c: float = None
     f14c_error: float = None
     sample_ids: Union[str, list[str]] = None
@@ -441,16 +1106,6 @@ class RadiocarbonDateCarbonateSample(CarbonateSample):
     delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
 
     def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
         if self._is_empty(self.conventional_age):
             self.MissingRequiredField("conventional_age")
         if not isinstance(self.conventional_age, float):
@@ -460,6 +1115,16 @@ class RadiocarbonDateCarbonateSample(CarbonateSample):
             self.MissingRequiredField("conventional_age_error")
         if not isinstance(self.conventional_age_error, float):
             self.conventional_age_error = float(self.conventional_age_error)
+
+        if self._is_empty(self.lab_code):
+            self.MissingRequiredField("lab_code")
+        if not isinstance(self.lab_code, LabCode):
+            self.lab_code = LabCode(self.lab_code)
+
+        if self._is_empty(self.lab_id):
+            self.MissingRequiredField("lab_id")
+        if not isinstance(self.lab_id, str):
+            self.lab_id = str(self.lab_id)
 
         if self._is_empty(self.f14c):
             self.MissingRequiredField("f14c")
@@ -577,974 +1242,6 @@ class RadiocarbonDateCarbonateSample(CarbonateSample):
         super().__post_init__(**kwargs)
 
 
-class Extension(YAMLRoot):
-    """
-    A collection of recommended metadata terms for a specific context
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["Extension"]
-    class_class_curie: ClassVar[str] = "c14:Extension"
-    class_name: ClassVar[str] = "Extension"
-    class_model_uri: ClassVar[URIRef] = C14.Extension
-
-
-@dataclass(repr=False)
-class ProteinaceousSample(Extension):
-    """
-    Terms specific to proteinaceous samples being dated
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["ProteinaceousSample"]
-    class_class_curie: ClassVar[str] = "c14:ProteinaceousSample"
-    class_name: ClassVar[str] = "ProteinaceousSample"
-    class_model_uri: ClassVar[URIRef] = C14.ProteinaceousSample
-
-    carbon_nitro_ratio: float = None
-    delta_15_n: Optional[float] = None
-    delta_15_n_error: Optional[float] = None
-    delta_34_s: Optional[float] = None
-    delta_34_s_error: Optional[float] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.carbon_nitro_ratio):
-            self.MissingRequiredField("carbon_nitro_ratio")
-        if not isinstance(self.carbon_nitro_ratio, float):
-            self.carbon_nitro_ratio = float(self.carbon_nitro_ratio)
-
-        if self.delta_15_n is not None and not isinstance(self.delta_15_n, float):
-            self.delta_15_n = float(self.delta_15_n)
-
-        if self.delta_15_n_error is not None and not isinstance(self.delta_15_n_error, float):
-            self.delta_15_n_error = float(self.delta_15_n_error)
-
-        if self.delta_34_s is not None and not isinstance(self.delta_34_s, float):
-            self.delta_34_s = float(self.delta_34_s)
-
-        if self.delta_34_s_error is not None and not isinstance(self.delta_34_s_error, float):
-            self.delta_34_s_error = float(self.delta_34_s_error)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class CarbonateSample(Extension):
-    """
-    Terms specific to carbonate samples being dated
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["CarbonateSample"]
-    class_class_curie: ClassVar[str] = "c14:CarbonateSample"
-    class_name: ClassVar[str] = "CarbonateSample"
-    class_model_uri: ClassVar[URIRef] = C14.CarbonateSample
-
-    recrystalisation: Union[bool, Bool] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.recrystalisation):
-            self.MissingRequiredField("recrystalisation")
-        if not isinstance(self.recrystalisation, Bool):
-            self.recrystalisation = Bool(self.recrystalisation)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class RadiocarbonDateProteinaceousSample(ProteinaceousSample):
-    """
-    A radiocarbon determination on a proteinaceous sample
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["RadiocarbonDateProteinaceousSample"]
-    class_class_curie: ClassVar[str] = "c14:RadiocarbonDateProteinaceousSample"
-    class_name: ClassVar[str] = "RadiocarbonDateProteinaceousSample"
-    class_model_uri: ClassVar[URIRef] = C14.RadiocarbonDateProteinaceousSample
-
-    carbon_nitro_ratio: float = None
-    lab_code: Union[str, "LabCode"] = None
-    lab_id: str = None
-    f14c: float = None
-    f14c_error: float = None
-    sample_ids: Union[str, list[str]] = None
-    sample_material: str = None
-    sample_taxon_id: Union[str, list[str]] = None
-    sample_taxon_id_confidence: Union[bool, Bool] = None
-    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
-    pretreatment_method_description: str = None
-    pretreatment_method_protocol: Union[str, list[str]] = None
-    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
-    sample_starting_weight: float = None
-    pretreatment_yield: float = None
-    carbon_proportion: float = None
-    suspected_reservoir_effect: Union[bool, Bool] = None
-    conventional_age: Optional[float] = None
-    conventional_age_error: Optional[float] = None
-    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    sample_taxon_scientific_name: Optional[str] = None
-    sample_anatomical_part: Optional[str] = None
-    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
-    suspected_sample_contamination_description: Optional[str] = None
-    sample_location: Optional[str] = None
-    decimal_latitude: Optional[float] = None
-    decimal_longitude: Optional[float] = None
-    coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
-    delta_13_c: Optional[float] = None
-    delta_13_c_error: Optional[float] = None
-    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.f14c):
-            self.MissingRequiredField("f14c")
-        if not isinstance(self.f14c, float):
-            self.f14c = float(self.f14c)
-
-        if self._is_empty(self.f14c_error):
-            self.MissingRequiredField("f14c_error")
-        if not isinstance(self.f14c_error, float):
-            self.f14c_error = float(self.f14c_error)
-
-        if self._is_empty(self.sample_ids):
-            self.MissingRequiredField("sample_ids")
-        if not isinstance(self.sample_ids, list):
-            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
-        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
-
-        if self._is_empty(self.sample_material):
-            self.MissingRequiredField("sample_material")
-        if not isinstance(self.sample_material, str):
-            self.sample_material = str(self.sample_material)
-
-        if self._is_empty(self.sample_taxon_id):
-            self.MissingRequiredField("sample_taxon_id")
-        if not isinstance(self.sample_taxon_id, list):
-            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
-        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
-
-        if self._is_empty(self.sample_taxon_id_confidence):
-            self.MissingRequiredField("sample_taxon_id_confidence")
-        if not isinstance(self.sample_taxon_id_confidence, Bool):
-            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
-
-        if self._is_empty(self.pretreatment_methods):
-            self.MissingRequiredField("pretreatment_methods")
-        if not isinstance(self.pretreatment_methods, list):
-            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
-        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
-
-        if self._is_empty(self.pretreatment_method_description):
-            self.MissingRequiredField("pretreatment_method_description")
-        if not isinstance(self.pretreatment_method_description, str):
-            self.pretreatment_method_description = str(self.pretreatment_method_description)
-
-        if self._is_empty(self.pretreatment_method_protocol):
-            self.MissingRequiredField("pretreatment_method_protocol")
-        if not isinstance(self.pretreatment_method_protocol, list):
-            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
-        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
-
-        if self._is_empty(self.measurement_method):
-            self.MissingRequiredField("measurement_method")
-        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
-            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
-
-        if self._is_empty(self.sample_starting_weight):
-            self.MissingRequiredField("sample_starting_weight")
-        if not isinstance(self.sample_starting_weight, float):
-            self.sample_starting_weight = float(self.sample_starting_weight)
-
-        if self._is_empty(self.pretreatment_yield):
-            self.MissingRequiredField("pretreatment_yield")
-        if not isinstance(self.pretreatment_yield, float):
-            self.pretreatment_yield = float(self.pretreatment_yield)
-
-        if self._is_empty(self.carbon_proportion):
-            self.MissingRequiredField("carbon_proportion")
-        if not isinstance(self.carbon_proportion, float):
-            self.carbon_proportion = float(self.carbon_proportion)
-
-        if self._is_empty(self.suspected_reservoir_effect):
-            self.MissingRequiredField("suspected_reservoir_effect")
-        if not isinstance(self.suspected_reservoir_effect, Bool):
-            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
-
-        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
-
-        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
-            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
-
-        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
-            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
-
-        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
-            self.sample_anatomical_part = str(self.sample_anatomical_part)
-
-        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
-            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
-
-        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
-            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
-
-        if self.sample_location is not None and not isinstance(self.sample_location, str):
-            self.sample_location = str(self.sample_location)
-
-        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
-            self.decimal_latitude = float(self.decimal_latitude)
-
-        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
-            self.decimal_longitude = float(self.decimal_longitude)
-
-        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
-            self.coordinate_precision = float(self.coordinate_precision)
-
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
-
-        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
-            self.delta_13_c = float(self.delta_13_c)
-
-        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
-            self.delta_13_c_error = float(self.delta_13_c_error)
-
-        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
-            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class RadiocarbonDateCarbonateSample(CarbonateSample):
-    """
-    A radiocarbon determination on a carbonate sample
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["RadiocarbonDateCarbonateSample"]
-    class_class_curie: ClassVar[str] = "c14:RadiocarbonDateCarbonateSample"
-    class_name: ClassVar[str] = "RadiocarbonDateCarbonateSample"
-    class_model_uri: ClassVar[URIRef] = C14.RadiocarbonDateCarbonateSample
-
-    recrystalisation: Union[bool, Bool] = None
-    lab_code: Union[str, "LabCode"] = None
-    lab_id: str = None
-    f14c: float = None
-    f14c_error: float = None
-    sample_ids: Union[str, list[str]] = None
-    sample_material: str = None
-    sample_taxon_id: Union[str, list[str]] = None
-    sample_taxon_id_confidence: Union[bool, Bool] = None
-    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
-    pretreatment_method_description: str = None
-    pretreatment_method_protocol: Union[str, list[str]] = None
-    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
-    sample_starting_weight: float = None
-    pretreatment_yield: float = None
-    carbon_proportion: float = None
-    suspected_reservoir_effect: Union[bool, Bool] = None
-    conventional_age: Optional[float] = None
-    conventional_age_error: Optional[float] = None
-    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    sample_taxon_scientific_name: Optional[str] = None
-    sample_anatomical_part: Optional[str] = None
-    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
-    suspected_sample_contamination_description: Optional[str] = None
-    sample_location: Optional[str] = None
-    decimal_latitude: Optional[float] = None
-    decimal_longitude: Optional[float] = None
-    coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
-    delta_13_c: Optional[float] = None
-    delta_13_c_error: Optional[float] = None
-    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.f14c):
-            self.MissingRequiredField("f14c")
-        if not isinstance(self.f14c, float):
-            self.f14c = float(self.f14c)
-
-        if self._is_empty(self.f14c_error):
-            self.MissingRequiredField("f14c_error")
-        if not isinstance(self.f14c_error, float):
-            self.f14c_error = float(self.f14c_error)
-
-        if self._is_empty(self.sample_ids):
-            self.MissingRequiredField("sample_ids")
-        if not isinstance(self.sample_ids, list):
-            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
-        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
-
-        if self._is_empty(self.sample_material):
-            self.MissingRequiredField("sample_material")
-        if not isinstance(self.sample_material, str):
-            self.sample_material = str(self.sample_material)
-
-        if self._is_empty(self.sample_taxon_id):
-            self.MissingRequiredField("sample_taxon_id")
-        if not isinstance(self.sample_taxon_id, list):
-            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
-        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
-
-        if self._is_empty(self.sample_taxon_id_confidence):
-            self.MissingRequiredField("sample_taxon_id_confidence")
-        if not isinstance(self.sample_taxon_id_confidence, Bool):
-            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
-
-        if self._is_empty(self.pretreatment_methods):
-            self.MissingRequiredField("pretreatment_methods")
-        if not isinstance(self.pretreatment_methods, list):
-            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
-        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
-
-        if self._is_empty(self.pretreatment_method_description):
-            self.MissingRequiredField("pretreatment_method_description")
-        if not isinstance(self.pretreatment_method_description, str):
-            self.pretreatment_method_description = str(self.pretreatment_method_description)
-
-        if self._is_empty(self.pretreatment_method_protocol):
-            self.MissingRequiredField("pretreatment_method_protocol")
-        if not isinstance(self.pretreatment_method_protocol, list):
-            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
-        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
-
-        if self._is_empty(self.measurement_method):
-            self.MissingRequiredField("measurement_method")
-        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
-            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
-
-        if self._is_empty(self.sample_starting_weight):
-            self.MissingRequiredField("sample_starting_weight")
-        if not isinstance(self.sample_starting_weight, float):
-            self.sample_starting_weight = float(self.sample_starting_weight)
-
-        if self._is_empty(self.pretreatment_yield):
-            self.MissingRequiredField("pretreatment_yield")
-        if not isinstance(self.pretreatment_yield, float):
-            self.pretreatment_yield = float(self.pretreatment_yield)
-
-        if self._is_empty(self.carbon_proportion):
-            self.MissingRequiredField("carbon_proportion")
-        if not isinstance(self.carbon_proportion, float):
-            self.carbon_proportion = float(self.carbon_proportion)
-
-        if self._is_empty(self.suspected_reservoir_effect):
-            self.MissingRequiredField("suspected_reservoir_effect")
-        if not isinstance(self.suspected_reservoir_effect, Bool):
-            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
-
-        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
-
-        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
-            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
-
-        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
-            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
-
-        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
-            self.sample_anatomical_part = str(self.sample_anatomical_part)
-
-        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
-            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
-
-        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
-            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
-
-        if self.sample_location is not None and not isinstance(self.sample_location, str):
-            self.sample_location = str(self.sample_location)
-
-        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
-            self.decimal_latitude = float(self.decimal_latitude)
-
-        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
-            self.decimal_longitude = float(self.decimal_longitude)
-
-        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
-            self.coordinate_precision = float(self.coordinate_precision)
-
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
-
-        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
-            self.delta_13_c = float(self.delta_13_c)
-
-        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
-            self.delta_13_c_error = float(self.delta_13_c_error)
-
-        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
-            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample):
-    """
-    F14C value radiocarbon date of a proteinaceous sample
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateProteinaceousSample"]
-    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateProteinaceousSample"
-    class_name: ClassVar[str] = "F14CRadiocarbonDateProteinaceousSample"
-    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateProteinaceousSample
-
-    carbon_nitro_ratio: float = None
-    lab_code: Union[str, "LabCode"] = None
-    lab_id: str = None
-    f14c: float = None
-    f14c_error: float = None
-    sample_ids: Union[str, list[str]] = None
-    sample_material: str = None
-    sample_taxon_id: Union[str, list[str]] = None
-    sample_taxon_id_confidence: Union[bool, Bool] = None
-    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
-    pretreatment_method_description: str = None
-    pretreatment_method_protocol: Union[str, list[str]] = None
-    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
-    sample_starting_weight: float = None
-    pretreatment_yield: float = None
-    carbon_proportion: float = None
-    suspected_reservoir_effect: Union[bool, Bool] = None
-    conventional_age: Optional[float] = None
-    conventional_age_error: Optional[float] = None
-    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    sample_taxon_scientific_name: Optional[str] = None
-    sample_anatomical_part: Optional[str] = None
-    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
-    suspected_sample_contamination_description: Optional[str] = None
-    sample_location: Optional[str] = None
-    decimal_latitude: Optional[float] = None
-    decimal_longitude: Optional[float] = None
-    coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
-    delta_13_c: Optional[float] = None
-    delta_13_c_error: Optional[float] = None
-    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.f14c):
-            self.MissingRequiredField("f14c")
-        if not isinstance(self.f14c, float):
-            self.f14c = float(self.f14c)
-
-        if self._is_empty(self.f14c_error):
-            self.MissingRequiredField("f14c_error")
-        if not isinstance(self.f14c_error, float):
-            self.f14c_error = float(self.f14c_error)
-
-        if self._is_empty(self.sample_ids):
-            self.MissingRequiredField("sample_ids")
-        if not isinstance(self.sample_ids, list):
-            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
-        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
-
-        if self._is_empty(self.sample_material):
-            self.MissingRequiredField("sample_material")
-        if not isinstance(self.sample_material, str):
-            self.sample_material = str(self.sample_material)
-
-        if self._is_empty(self.sample_taxon_id):
-            self.MissingRequiredField("sample_taxon_id")
-        if not isinstance(self.sample_taxon_id, list):
-            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
-        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
-
-        if self._is_empty(self.sample_taxon_id_confidence):
-            self.MissingRequiredField("sample_taxon_id_confidence")
-        if not isinstance(self.sample_taxon_id_confidence, Bool):
-            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
-
-        if self._is_empty(self.pretreatment_methods):
-            self.MissingRequiredField("pretreatment_methods")
-        if not isinstance(self.pretreatment_methods, list):
-            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
-        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
-
-        if self._is_empty(self.pretreatment_method_description):
-            self.MissingRequiredField("pretreatment_method_description")
-        if not isinstance(self.pretreatment_method_description, str):
-            self.pretreatment_method_description = str(self.pretreatment_method_description)
-
-        if self._is_empty(self.pretreatment_method_protocol):
-            self.MissingRequiredField("pretreatment_method_protocol")
-        if not isinstance(self.pretreatment_method_protocol, list):
-            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
-        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
-
-        if self._is_empty(self.measurement_method):
-            self.MissingRequiredField("measurement_method")
-        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
-            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
-
-        if self._is_empty(self.sample_starting_weight):
-            self.MissingRequiredField("sample_starting_weight")
-        if not isinstance(self.sample_starting_weight, float):
-            self.sample_starting_weight = float(self.sample_starting_weight)
-
-        if self._is_empty(self.pretreatment_yield):
-            self.MissingRequiredField("pretreatment_yield")
-        if not isinstance(self.pretreatment_yield, float):
-            self.pretreatment_yield = float(self.pretreatment_yield)
-
-        if self._is_empty(self.carbon_proportion):
-            self.MissingRequiredField("carbon_proportion")
-        if not isinstance(self.carbon_proportion, float):
-            self.carbon_proportion = float(self.carbon_proportion)
-
-        if self._is_empty(self.suspected_reservoir_effect):
-            self.MissingRequiredField("suspected_reservoir_effect")
-        if not isinstance(self.suspected_reservoir_effect, Bool):
-            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
-
-        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
-
-        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
-            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
-
-        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
-            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
-
-        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
-            self.sample_anatomical_part = str(self.sample_anatomical_part)
-
-        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
-            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
-
-        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
-            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
-
-        if self.sample_location is not None and not isinstance(self.sample_location, str):
-            self.sample_location = str(self.sample_location)
-
-        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
-            self.decimal_latitude = float(self.decimal_latitude)
-
-        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
-            self.decimal_longitude = float(self.decimal_longitude)
-
-        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
-            self.coordinate_precision = float(self.coordinate_precision)
-
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
-
-        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
-            self.delta_13_c = float(self.delta_13_c)
-
-        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
-            self.delta_13_c_error = float(self.delta_13_c_error)
-
-        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
-            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class F14CRadiocarbonDateCarbonateSample(CarbonateSample):
-    """
-    F14C value radiocarbon date of a carbonate sample
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["F14CRadiocarbonDateCarbonateSample"]
-    class_class_curie: ClassVar[str] = "c14:F14CRadiocarbonDateCarbonateSample"
-    class_name: ClassVar[str] = "F14CRadiocarbonDateCarbonateSample"
-    class_model_uri: ClassVar[URIRef] = C14.F14CRadiocarbonDateCarbonateSample
-
-    recrystalisation: Union[bool, Bool] = None
-    lab_code: Union[str, "LabCode"] = None
-    lab_id: str = None
-    f14c: float = None
-    f14c_error: float = None
-    sample_ids: Union[str, list[str]] = None
-    sample_material: str = None
-    sample_taxon_id: Union[str, list[str]] = None
-    sample_taxon_id_confidence: Union[bool, Bool] = None
-    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
-    pretreatment_method_description: str = None
-    pretreatment_method_protocol: Union[str, list[str]] = None
-    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
-    sample_starting_weight: float = None
-    pretreatment_yield: float = None
-    carbon_proportion: float = None
-    suspected_reservoir_effect: Union[bool, Bool] = None
-    conventional_age: Optional[float] = None
-    conventional_age_error: Optional[float] = None
-    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    sample_taxon_scientific_name: Optional[str] = None
-    sample_anatomical_part: Optional[str] = None
-    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
-    suspected_sample_contamination_description: Optional[str] = None
-    sample_location: Optional[str] = None
-    decimal_latitude: Optional[float] = None
-    decimal_longitude: Optional[float] = None
-    coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
-    delta_13_c: Optional[float] = None
-    delta_13_c_error: Optional[float] = None
-    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.f14c):
-            self.MissingRequiredField("f14c")
-        if not isinstance(self.f14c, float):
-            self.f14c = float(self.f14c)
-
-        if self._is_empty(self.f14c_error):
-            self.MissingRequiredField("f14c_error")
-        if not isinstance(self.f14c_error, float):
-            self.f14c_error = float(self.f14c_error)
-
-        if self._is_empty(self.sample_ids):
-            self.MissingRequiredField("sample_ids")
-        if not isinstance(self.sample_ids, list):
-            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
-        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
-
-        if self._is_empty(self.sample_material):
-            self.MissingRequiredField("sample_material")
-        if not isinstance(self.sample_material, str):
-            self.sample_material = str(self.sample_material)
-
-        if self._is_empty(self.sample_taxon_id):
-            self.MissingRequiredField("sample_taxon_id")
-        if not isinstance(self.sample_taxon_id, list):
-            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
-        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
-
-        if self._is_empty(self.sample_taxon_id_confidence):
-            self.MissingRequiredField("sample_taxon_id_confidence")
-        if not isinstance(self.sample_taxon_id_confidence, Bool):
-            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
-
-        if self._is_empty(self.pretreatment_methods):
-            self.MissingRequiredField("pretreatment_methods")
-        if not isinstance(self.pretreatment_methods, list):
-            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
-        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
-
-        if self._is_empty(self.pretreatment_method_description):
-            self.MissingRequiredField("pretreatment_method_description")
-        if not isinstance(self.pretreatment_method_description, str):
-            self.pretreatment_method_description = str(self.pretreatment_method_description)
-
-        if self._is_empty(self.pretreatment_method_protocol):
-            self.MissingRequiredField("pretreatment_method_protocol")
-        if not isinstance(self.pretreatment_method_protocol, list):
-            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
-        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
-
-        if self._is_empty(self.measurement_method):
-            self.MissingRequiredField("measurement_method")
-        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
-            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
-
-        if self._is_empty(self.sample_starting_weight):
-            self.MissingRequiredField("sample_starting_weight")
-        if not isinstance(self.sample_starting_weight, float):
-            self.sample_starting_weight = float(self.sample_starting_weight)
-
-        if self._is_empty(self.pretreatment_yield):
-            self.MissingRequiredField("pretreatment_yield")
-        if not isinstance(self.pretreatment_yield, float):
-            self.pretreatment_yield = float(self.pretreatment_yield)
-
-        if self._is_empty(self.carbon_proportion):
-            self.MissingRequiredField("carbon_proportion")
-        if not isinstance(self.carbon_proportion, float):
-            self.carbon_proportion = float(self.carbon_proportion)
-
-        if self._is_empty(self.suspected_reservoir_effect):
-            self.MissingRequiredField("suspected_reservoir_effect")
-        if not isinstance(self.suspected_reservoir_effect, Bool):
-            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
-
-        if self.conventional_age is not None and not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self.conventional_age_error is not None and not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
-
-        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
-            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
-
-        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
-            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
-
-        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
-            self.sample_anatomical_part = str(self.sample_anatomical_part)
-
-        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
-            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
-
-        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
-            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
-
-        if self.sample_location is not None and not isinstance(self.sample_location, str):
-            self.sample_location = str(self.sample_location)
-
-        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
-            self.decimal_latitude = float(self.decimal_latitude)
-
-        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
-            self.decimal_longitude = float(self.decimal_longitude)
-
-        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
-            self.coordinate_precision = float(self.coordinate_precision)
-
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
-
-        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
-            self.delta_13_c = float(self.delta_13_c)
-
-        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
-            self.delta_13_c_error = float(self.delta_13_c_error)
-
-        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
-            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
-
-        super().__post_init__(**kwargs)
-
-
-@dataclass(repr=False)
-class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample):
-    """
-    Conventional age radiocarbon date of a proteinaceous sample
-    """
-    _inherited_slots: ClassVar[list[str]] = []
-
-    class_class_uri: ClassVar[URIRef] = C14["ConventionalAgeRadiocarbonDateProteinaceousSample"]
-    class_class_curie: ClassVar[str] = "c14:ConventionalAgeRadiocarbonDateProteinaceousSample"
-    class_name: ClassVar[str] = "ConventionalAgeRadiocarbonDateProteinaceousSample"
-    class_model_uri: ClassVar[URIRef] = C14.ConventionalAgeRadiocarbonDateProteinaceousSample
-
-    carbon_nitro_ratio: float = None
-    conventional_age: float = None
-    conventional_age_error: float = None
-    lab_code: Union[str, "LabCode"] = None
-    lab_id: str = None
-    f14c: float = None
-    f14c_error: float = None
-    sample_ids: Union[str, list[str]] = None
-    sample_material: str = None
-    sample_taxon_id: Union[str, list[str]] = None
-    sample_taxon_id_confidence: Union[bool, Bool] = None
-    pretreatment_methods: Union[Union[str, "PretreatmentMethods"], list[Union[str, "PretreatmentMethods"]]] = None
-    pretreatment_method_description: str = None
-    pretreatment_method_protocol: Union[str, list[str]] = None
-    measurement_method: Union[str, "RadiocarbonMeasurementMethod"] = None
-    sample_starting_weight: float = None
-    pretreatment_yield: float = None
-    carbon_proportion: float = None
-    suspected_reservoir_effect: Union[bool, Bool] = None
-    delta_13_c_calculation_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-    sample_taxon_scientific_name: Optional[str] = None
-    sample_anatomical_part: Optional[str] = None
-    suspected_sample_contamination: Optional[Union[bool, Bool]] = None
-    suspected_sample_contamination_description: Optional[str] = None
-    sample_location: Optional[str] = None
-    decimal_latitude: Optional[float] = None
-    decimal_longitude: Optional[float] = None
-    coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
-    delta_13_c: Optional[float] = None
-    delta_13_c_error: Optional[float] = None
-    delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
-
-    def __post_init__(self, *_: str, **kwargs: Any):
-        if self._is_empty(self.conventional_age):
-            self.MissingRequiredField("conventional_age")
-        if not isinstance(self.conventional_age, float):
-            self.conventional_age = float(self.conventional_age)
-
-        if self._is_empty(self.conventional_age_error):
-            self.MissingRequiredField("conventional_age_error")
-        if not isinstance(self.conventional_age_error, float):
-            self.conventional_age_error = float(self.conventional_age_error)
-
-        if self._is_empty(self.lab_code):
-            self.MissingRequiredField("lab_code")
-        if not isinstance(self.lab_code, LabCode):
-            self.lab_code = LabCode(self.lab_code)
-
-        if self._is_empty(self.lab_id):
-            self.MissingRequiredField("lab_id")
-        if not isinstance(self.lab_id, str):
-            self.lab_id = str(self.lab_id)
-
-        if self._is_empty(self.f14c):
-            self.MissingRequiredField("f14c")
-        if not isinstance(self.f14c, float):
-            self.f14c = float(self.f14c)
-
-        if self._is_empty(self.f14c_error):
-            self.MissingRequiredField("f14c_error")
-        if not isinstance(self.f14c_error, float):
-            self.f14c_error = float(self.f14c_error)
-
-        if self._is_empty(self.sample_ids):
-            self.MissingRequiredField("sample_ids")
-        if not isinstance(self.sample_ids, list):
-            self.sample_ids = [self.sample_ids] if self.sample_ids is not None else []
-        self.sample_ids = [v if isinstance(v, str) else str(v) for v in self.sample_ids]
-
-        if self._is_empty(self.sample_material):
-            self.MissingRequiredField("sample_material")
-        if not isinstance(self.sample_material, str):
-            self.sample_material = str(self.sample_material)
-
-        if self._is_empty(self.sample_taxon_id):
-            self.MissingRequiredField("sample_taxon_id")
-        if not isinstance(self.sample_taxon_id, list):
-            self.sample_taxon_id = [self.sample_taxon_id] if self.sample_taxon_id is not None else []
-        self.sample_taxon_id = [v if isinstance(v, str) else str(v) for v in self.sample_taxon_id]
-
-        if self._is_empty(self.sample_taxon_id_confidence):
-            self.MissingRequiredField("sample_taxon_id_confidence")
-        if not isinstance(self.sample_taxon_id_confidence, Bool):
-            self.sample_taxon_id_confidence = Bool(self.sample_taxon_id_confidence)
-
-        if self._is_empty(self.pretreatment_methods):
-            self.MissingRequiredField("pretreatment_methods")
-        if not isinstance(self.pretreatment_methods, list):
-            self.pretreatment_methods = [self.pretreatment_methods] if self.pretreatment_methods is not None else []
-        self.pretreatment_methods = [v if isinstance(v, PretreatmentMethods) else PretreatmentMethods(v) for v in self.pretreatment_methods]
-
-        if self._is_empty(self.pretreatment_method_description):
-            self.MissingRequiredField("pretreatment_method_description")
-        if not isinstance(self.pretreatment_method_description, str):
-            self.pretreatment_method_description = str(self.pretreatment_method_description)
-
-        if self._is_empty(self.pretreatment_method_protocol):
-            self.MissingRequiredField("pretreatment_method_protocol")
-        if not isinstance(self.pretreatment_method_protocol, list):
-            self.pretreatment_method_protocol = [self.pretreatment_method_protocol] if self.pretreatment_method_protocol is not None else []
-        self.pretreatment_method_protocol = [v if isinstance(v, str) else str(v) for v in self.pretreatment_method_protocol]
-
-        if self._is_empty(self.measurement_method):
-            self.MissingRequiredField("measurement_method")
-        if not isinstance(self.measurement_method, RadiocarbonMeasurementMethod):
-            self.measurement_method = RadiocarbonMeasurementMethod(self.measurement_method)
-
-        if self._is_empty(self.sample_starting_weight):
-            self.MissingRequiredField("sample_starting_weight")
-        if not isinstance(self.sample_starting_weight, float):
-            self.sample_starting_weight = float(self.sample_starting_weight)
-
-        if self._is_empty(self.pretreatment_yield):
-            self.MissingRequiredField("pretreatment_yield")
-        if not isinstance(self.pretreatment_yield, float):
-            self.pretreatment_yield = float(self.pretreatment_yield)
-
-        if self._is_empty(self.carbon_proportion):
-            self.MissingRequiredField("carbon_proportion")
-        if not isinstance(self.carbon_proportion, float):
-            self.carbon_proportion = float(self.carbon_proportion)
-
-        if self._is_empty(self.suspected_reservoir_effect):
-            self.MissingRequiredField("suspected_reservoir_effect")
-        if not isinstance(self.suspected_reservoir_effect, Bool):
-            self.suspected_reservoir_effect = Bool(self.suspected_reservoir_effect)
-
-        if self.delta_13_c_calculation_method is not None and not isinstance(self.delta_13_c_calculation_method, Delta13CMeasurementMethod):
-            self.delta_13_c_calculation_method = Delta13CMeasurementMethod(self.delta_13_c_calculation_method)
-
-        if self.sample_taxon_scientific_name is not None and not isinstance(self.sample_taxon_scientific_name, str):
-            self.sample_taxon_scientific_name = str(self.sample_taxon_scientific_name)
-
-        if self.sample_anatomical_part is not None and not isinstance(self.sample_anatomical_part, str):
-            self.sample_anatomical_part = str(self.sample_anatomical_part)
-
-        if self.suspected_sample_contamination is not None and not isinstance(self.suspected_sample_contamination, Bool):
-            self.suspected_sample_contamination = Bool(self.suspected_sample_contamination)
-
-        if self.suspected_sample_contamination_description is not None and not isinstance(self.suspected_sample_contamination_description, str):
-            self.suspected_sample_contamination_description = str(self.suspected_sample_contamination_description)
-
-        if self.sample_location is not None and not isinstance(self.sample_location, str):
-            self.sample_location = str(self.sample_location)
-
-        if self.decimal_latitude is not None and not isinstance(self.decimal_latitude, float):
-            self.decimal_latitude = float(self.decimal_latitude)
-
-        if self.decimal_longitude is not None and not isinstance(self.decimal_longitude, float):
-            self.decimal_longitude = float(self.decimal_longitude)
-
-        if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
-            self.coordinate_precision = float(self.coordinate_precision)
-
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
-
-        if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
-            self.delta_13_c = float(self.delta_13_c)
-
-        if self.delta_13_c_error is not None and not isinstance(self.delta_13_c_error, float):
-            self.delta_13_c_error = float(self.delta_13_c_error)
-
-        if self.delta_13_c_method is not None and not isinstance(self.delta_13_c_method, Delta13CMeasurementMethod):
-            self.delta_13_c_method = Delta13CMeasurementMethod(self.delta_13_c_method)
-
-        super().__post_init__(**kwargs)
-
-
 @dataclass(repr=False)
 class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample):
     """
@@ -1585,7 +1282,7 @@ class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample):
     decimal_latitude: Optional[float] = None
     decimal_longitude: Optional[float] = None
     coordinate_precision: Optional[float] = None
-    pretreatment_percentage_yield: Optional[float] = None
+    pretreatment_proportion_yield: Optional[float] = None
     delta_13_c: Optional[float] = None
     delta_13_c_error: Optional[float] = None
     delta_13_c_method: Optional[Union[str, "Delta13CMeasurementMethod"]] = None
@@ -1712,8 +1409,8 @@ class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample):
         if self.coordinate_precision is not None and not isinstance(self.coordinate_precision, float):
             self.coordinate_precision = float(self.coordinate_precision)
 
-        if self.pretreatment_percentage_yield is not None and not isinstance(self.pretreatment_percentage_yield, float):
-            self.pretreatment_percentage_yield = float(self.pretreatment_percentage_yield)
+        if self.pretreatment_proportion_yield is not None and not isinstance(self.pretreatment_proportion_yield, float):
+            self.pretreatment_proportion_yield = float(self.pretreatment_proportion_yield)
 
         if self.delta_13_c is not None and not isinstance(self.delta_13_c, float):
             self.delta_13_c = float(self.delta_13_c)

--- a/src/c14/datamodel/c14_pydantic.py
+++ b/src/c14/datamodel/c14_pydantic.py
@@ -96,13 +96,6 @@ linkml_meta = LinkMLMeta({'default_prefix': 'c14',
                   'schema': {'prefix_prefix': 'schema',
                              'prefix_reference': 'http://schema.org/'}},
      'see_also': ['https://MIxS-MInAS.github.io/miaard'],
-     'settings': {'DOI': {'setting_key': 'DOI',
-                          'setting_value': '^https:\\/\\/doi\\.org\\/10.\\d{2,9}/.*$'},
-                  'PMID': {'setting_key': 'PMID', 'setting_value': '^PMID:\\d+$'},
-                  'URL': {'setting_key': 'URL',
-                          'setting_value': '^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$'},
-                  'termID': {'setting_key': 'termID',
-                             'setting_value': '[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+'}},
      'source_file': 'src/c14/schema/c14.yaml',
      'title': 'miaard'} )
 
@@ -1451,17 +1444,19 @@ without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml
                       {'value': '1415(a)'}],
          'slot_group': 'Identifier',
          'slot_uri': 'c14:000002'} })
-    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
 conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
 NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
 Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000005'} })
-    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
 normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
 Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000006'} })
     f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
@@ -1501,10 +1496,7 @@ Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENV
 organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
          'slot_group': 'Sample',
-         'slot_uri': 'c14:000009',
-         'structured_pattern': {'interpolated': True,
-                                'partial_match': False,
-                                'syntax': '^{termID}$'}} })
+         'slot_uri': 'c14:000009'} })
     sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
 radiocarbon measurement originated. The taxonomic ID should come from an established
 ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
@@ -1512,10 +1504,7 @@ ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['R
                       {'value': 'gbif:2441105'},
                       {'value': 'bold.taxonomy:786175'}],
          'slot_group': 'Sample',
-         'slot_uri': 'c14:000010',
-         'structured_pattern': {'interpolated': True,
-                                'partial_match': False,
-                                'syntax': '^{termID}$'}} })
+         'slot_uri': 'c14:000010'} })
     sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
 If secure identification, indicate TRUE, if identification is unclear or
 uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
@@ -1539,10 +1528,7 @@ taxonomic ID does not currently exist for the specific taxon.""", json_schema_ex
                       {'value': 'UBERON:3010209'}],
          'recommended': True,
          'slot_group': 'Sample',
-         'slot_uri': 'c14:000013',
-         'structured_pattern': {'interpolated': True,
-                                'partial_match': False,
-                                'syntax': '^{termID}$'}} })
+         'slot_uri': 'c14:000013'} })
     suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
 (organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': 'true'}, {'value': 'false'}],
@@ -1598,11 +1584,8 @@ and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['
          'slot_group': 'Method',
          'slot_uri': 'c14:000020'} })
     pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'}, {'value': ''}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI or URL to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Samples were pretreated following Brock et al. '
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
                                 '(2010). Briefly, bone was demineralised (0.5M HCl, '
                                 'overnight), washed in base (0.1M NaOH, 30 min, RT) '
                                 'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
@@ -1612,10 +1595,449 @@ and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['
                                 'shell leaving dense translucent carbonate;  Charcoal '
                                 'was treated with HCl, NaOH and HCl.'}],
          'slot_group': 'Method',
-         'slot_uri': 'c14:000022',
-         'structured_pattern': {'interpolated': True,
-                                'partial_match': False,
-                                'syntax': '^{PMID}|{DOI}|{URL}|{text}$'}} })
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class RadiocarbonDateCollection(ConfiguredBaseModel):
+    """
+    A collection of radiocarbon determinations with associated metadata.
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/MIxS-MInAS/miaard', 'tree_root': True})
+
+    entries: Optional[list[RadiocarbonDate]] = Field(default=[], description="""A list of multiple radiocarbon determinations.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDateCollection']} })
+
+
+class Extension(ConfiguredBaseModel):
+    """
+    A collection of recommended metadata terms for a specific context
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/MIxS-MInAS/miaard'})
+
+    pass
+
+
+class ProteinaceousSample(Extension):
+    """
+    Terms specific to proteinaceous samples being dated
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ProteinaceousSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'title': 'Proteinaceous Sample'})
+
+    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '3.2'}, {'value': '3.33'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000032'} })
+    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000033'} })
+    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.3'}, {'value': '0.12'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000034'} })
+    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000035'} })
+    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.4'}, {'value': '0.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000036'} })
+
+
+class CarbonateSample(Extension):
+    """
+    Terms specific to carbonate samples being dated
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:CarbonateSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'title': 'Carbonate Sample'})
+
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+
+class RadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
+    """
+    A radiocarbon determination on a proteinaceous sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:RadiocarbonDateProteinaceousSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'Radiocarbon Date (Proteinaceous Sample)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
     measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
          'slot_group': 'Method',
@@ -1665,38 +2087,34 @@ should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000031'} })
     carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
-proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
          'examples': [{'value': '3.2'}, {'value': '3.33'}],
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000032'} })
     delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
-15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
          'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
          'recommended': True,
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000033'} })
     delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
          'examples': [{'value': '0.3'}, {'value': '0.12'}],
          'recommended': True,
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000034'} })
     delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
-34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
          'examples': [{'value': '18.4'}, {'value': '-5.2'}],
          'recommended': False,
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000035'} })
     delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
          'examples': [{'value': '0.4'}, {'value': '0.2'}],
          'recommended': False,
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000036'} })
-    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000037'} })
 
     @field_validator('lab_id')
     def pattern_lab_id(cls, v):
@@ -1724,6 +2142,32 @@ Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { 
             raise ValueError(err_msg)
         return v
 
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
     @field_validator('sample_taxon_scientific_name')
     def pattern_sample_taxon_scientific_name(cls, v):
         pattern=re.compile(r"")
@@ -1734,6 +2178,19 @@ Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { 
                     raise ValueError(err_msg)
         elif isinstance(v, str) and not pattern.match(v):
             err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
             raise ValueError(err_msg)
         return v
 
@@ -1776,17 +2233,1933 @@ Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { 
             raise ValueError(err_msg)
         return v
 
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
 
-class RadiocarbonDateCollection(ConfiguredBaseModel):
-    """
-    A collection of radiocarbon determinations with associated metadata.
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/MIxS-MInAS/miaard', 'tree_root': True})
 
-    entries: Optional[list[RadiocarbonDate]] = Field(default=[], description="""A list of multiple radiocarbon determinations.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDateCollection']} })
+class RadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
+    """
+    A radiocarbon determination on a carbonate sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:RadiocarbonDateCarbonateSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'Radiocarbon Date (Carbonate Sample)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
+    """
+    F14C value radiocarbon date of a proteinaceous sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateProteinaceousSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'F14C value radiocarbon date (proteinaceous)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '3.2'}, {'value': '3.33'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000032'} })
+    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000033'} })
+    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.3'}, {'value': '0.12'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000034'} })
+    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000035'} })
+    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.4'}, {'value': '0.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000036'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class F14CRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
+    """
+    F14C value radiocarbon date of a carbonate sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateCarbonateSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'F14C value radiocarbon date (carbonate)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
+    """
+    Conventional age radiocarbon date of a proteinaceous sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateProteinaceousSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'slot_usage': {'conventional_age': {'name': 'conventional_age',
+                                             'required': True},
+                        'conventional_age_error': {'name': 'conventional_age_error',
+                                                   'required': True}},
+         'title': 'Conventional age radiocarbon date (proteinaceous)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '3.2'}, {'value': '3.33'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000032'} })
+    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000033'} })
+    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.3'}, {'value': '0.12'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000034'} })
+    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000035'} })
+    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.4'}, {'value': '0.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000036'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
+    """
+    Conventional age radiocarbon date of a carbonate sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateCarbonateSample',
+         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
+         'mixins': ['RadiocarbonDate'],
+         'slot_usage': {'conventional_age': {'name': 'conventional_age',
+                                             'required': True},
+                        'conventional_age_error': {'name': 'conventional_age_error',
+                                                   'required': True}},
+         'title': 'Conventional age radiocarbon date (carbonate)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate TRUE, if identification is unclear or
+uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
 
 
 # Model rebuild
 # see https://pydantic-docs.helpmanual.io/usage/models/#rebuilding-a-model
 RadiocarbonDate.model_rebuild()
 RadiocarbonDateCollection.model_rebuild()
+Extension.model_rebuild()
+ProteinaceousSample.model_rebuild()
+CarbonateSample.model_rebuild()
+RadiocarbonDateProteinaceousSample.model_rebuild()
+RadiocarbonDateCarbonateSample.model_rebuild()
+F14CRadiocarbonDateProteinaceousSample.model_rebuild()
+F14CRadiocarbonDateCarbonateSample.model_rebuild()
+ConventionalAgeRadiocarbonDateProteinaceousSample.model_rebuild()
+ConventionalAgeRadiocarbonDateCarbonateSample.model_rebuild()

--- a/src/c14/datamodel/c14_pydantic.py
+++ b/src/c14/datamodel/c14_pydantic.py
@@ -95,7 +95,7 @@ linkml_meta = LinkMLMeta({'default_prefix': 'c14',
                              'prefix_reference': 'https://w3id.org/linkml/'},
                   'schema': {'prefix_prefix': 'schema',
                              'prefix_reference': 'http://schema.org/'}},
-     'see_also': ['https://MIxS-MInAS.github.io/miaard'],
+     'see_also': ['https://miaard.github.io/miaard-schema'],
      'source_file': 'src/c14/schema/c14.yaml',
      'title': 'miaard'} )
 
@@ -1505,9 +1505,9 @@ ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['R
                       {'value': 'bold.taxonomy:786175'}],
          'slot_group': 'Sample',
          'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confident in taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate 'true', if identification is unclear or
+uncertain specify 'false'.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': 'true'}, {'value': 'false'}],
          'slot_group': 'Sample',
          'slot_uri': 'c14:000011'} })
@@ -1529,8 +1529,8 @@ taxonomic ID does not currently exist for the specific taxon.""", json_schema_ex
          'recommended': True,
          'slot_group': 'Sample',
          'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': 'true'}, {'value': 'false'}],
          'recommended': True,
          'slot_group': 'Sample',
@@ -1606,15 +1606,15 @@ and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['
          'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
          'slot_group': 'Method',
          'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '22'}, {'value': '2.3'}],
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '012'},
                       {'value': '0.61'},
                       {'value': '0.015'},
@@ -1786,2367 +1786,9 @@ class RadiocarbonDateCollection(ConfiguredBaseModel):
     """
     A collection of radiocarbon determinations with associated metadata.
     """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/MIxS-MInAS/miaard', 'tree_root': True})
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/miaard/miaard-schema', 'tree_root': True})
 
     entries: Optional[list[RadiocarbonDate]] = Field(default=[], description="""A list of multiple radiocarbon determinations.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDateCollection']} })
-
-
-class Extension(ConfiguredBaseModel):
-    """
-    A collection of recommended metadata terms for a specific context
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'from_schema': 'https://w3id.org/MIxS-MInAS/miaard'})
-
-    pass
-
-
-class ProteinaceousSample(Extension):
-    """
-    Terms specific to proteinaceous samples being dated
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ProteinaceousSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'title': 'Proteinaceous Sample'})
-
-    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
-proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '3.2'}, {'value': '3.33'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000032'} })
-    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
-15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000033'} })
-    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.3'}, {'value': '0.12'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000034'} })
-    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
-34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000035'} })
-    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.4'}, {'value': '0.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000036'} })
-
-
-class CarbonateSample(Extension):
-    """
-    Terms specific to carbonate samples being dated
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:CarbonateSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'title': 'Carbonate Sample'})
-
-    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000037'} })
-
-
-class RadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
-    """
-    A radiocarbon determination on a proteinaceous sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:RadiocarbonDateProteinaceousSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'title': 'Radiocarbon Date (Proteinaceous Sample)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
-proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '3.2'}, {'value': '3.33'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000032'} })
-    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
-15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000033'} })
-    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.3'}, {'value': '0.12'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000034'} })
-    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
-34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000035'} })
-    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.4'}, {'value': '0.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000036'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-class RadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
-    """
-    A radiocarbon determination on a carbonate sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:RadiocarbonDateCarbonateSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'title': 'Radiocarbon Date (Carbonate Sample)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000037'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-
-class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
-    """
-    F14C value radiocarbon date of a proteinaceous sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateProteinaceousSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'title': 'F14C value radiocarbon date (proteinaceous)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
-proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '3.2'}, {'value': '3.33'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000032'} })
-    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
-15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000033'} })
-    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.3'}, {'value': '0.12'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000034'} })
-    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
-34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000035'} })
-    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.4'}, {'value': '0.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000036'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-
-class F14CRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
-    """
-    F14C value radiocarbon date of a carbonate sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateCarbonateSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'title': 'F14C value radiocarbon date (carbonate)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000037'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-
-class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
-    """
-    Conventional age radiocarbon date of a proteinaceous sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateProteinaceousSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'slot_usage': {'conventional_age': {'name': 'conventional_age',
-                                             'required': True},
-                        'conventional_age_error': {'name': 'conventional_age_error',
-                                                   'required': True}},
-         'title': 'Conventional age radiocarbon date (proteinaceous)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
-proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '3.2'}, {'value': '3.33'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000032'} })
-    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
-15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000033'} })
-    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.3'}, {'value': '0.12'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000034'} })
-    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
-34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000035'} })
-    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
-         'examples': [{'value': '0.4'}, {'value': '0.2'}],
-         'recommended': False,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000036'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-
-class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
-    """
-    Conventional age radiocarbon date of a carbonate sample
-    """
-    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateCarbonateSample',
-         'from_schema': 'https://w3id.org/MIxS-MInAS/miaard',
-         'mixins': ['RadiocarbonDate'],
-         'slot_usage': {'conventional_age': {'name': 'conventional_age',
-                                             'required': True},
-                        'conventional_age_error': {'name': 'conventional_age_error',
-                                                   'required': True}},
-         'title': 'Conventional age radiocarbon date (carbonate)'})
-
-    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
-This is the prefix used for each determination ID. The prefix should be
-derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'OxA'},
-                      {'value': 'CAMS'},
-                      {'value': 'Beta'},
-                      {'value': 'CN-XX'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000001'} })
-    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
-without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '982744'},
-                      {'value': 'i238493'},
-                      {'value': '9800507B'},
-                      {'value': '-X-1045-13'},
-                      {'value': '1415(a)'}],
-         'slot_group': 'Identifier',
-         'slot_uri': 'c14:000002'} })
-    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
-conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
-NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
-Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '4500'}, {'value': '37330'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000005'} })
-    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
-normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '25'}, {'value': '620'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000006'} })
-    f14c: float = Field(default=..., description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
-For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000003'} })
-    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
-normally indicated as a ± after the main value. Must be in the same format.
-Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000004'} })
-    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Was the radiocarbon date calculated with an AMS derived δ13C, an IRMS derived δ13C,
-an alternative δ13C measurement method or an assumed δ13C""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'},
-                      {'value': 'IRMS'},
-                      {'value': 'Assumed'},
-                      {'value': 'Other'}],
-         'recommended': True,
-         'slot_group': 'Measurement',
-         'slot_uri': 'c14:000007'} })
-    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
-(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'PES001'},
-                      {'value': 'PES001.B1010'},
-                      {'value': 'Des 207 d'},
-                      {'value': 'Grave 78'},
-                      {'value': 'Box 427; Exc. year 1926 (small)'},
-                      {'value': 'KrSp E1/2012/E1/3775'},
-                      {'value': 'Iceman'},
-                      {'value': 'Tumba XVIII'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000008'} })
-    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
-Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000009'} })
-    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
-radiocarbon measurement originated. The taxonomic ID should come from an established
-ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'NCBITAXON:9606'},
-                      {'value': 'gbif:2441105'},
-                      {'value': 'bold.taxonomy:786175'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000010'} })
-    sample_taxon_id_confidence: bool = Field(default=..., title="Confidence of taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
-If secure identification, indicate TRUE, if identification is unclear or
-uncertain specify FALSE.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000011'} })
-    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
-taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'Mammathus primigenius'},
-                      {'value': 'cf Mammathus'},
-                      {'value': 'Homo sapiens sapiens'},
-                      {'value': 'Capra sp.'},
-                      {'value': 'Ulmus davidiana var. japonica'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000012'} })
-    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived.", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'UBERON:0000981'},
-                      {'value': 'PO:0009010'},
-                      {'value': 'BTO:0001411'},
-                      {'value': 'UBERON:3010209'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000013'} })
-    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination.", description="""Specify whether the sample has suspected contamination that may influence measurement
-(organic glue, consolidant, rootlets, embalming solution, staining etc.)""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000014'} })
-    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
-description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'glue'},
-                      {'value': 'organic glue made from horse'},
-                      {'value': 'staining'},
-                      {'value': 'bitumen'},
-                      {'value': 'rootlets'},
-                      {'value': 'Consolidant was applied to the skull to stabilise the '
-                                'bone.'},
-                      {'value': 'Sample was preserved in a embalming solution '
-                                'containing formaldehyde and alcohol.'}],
-         'recommended': False,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000015'} })
-    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of location from which the sample originated""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': ''}, {'value': ''}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000016'} })
-    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
-of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000017'} })
-    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
-geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
-negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000018'} })
-    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
-and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
-         'recommended': True,
-         'slot_group': 'Sample',
-         'slot_uri': 'c14:000019'} })
-    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'ABA'},
-                      {'value': 'A'},
-                      {'value': 'BABA'},
-                      {'value': 'Col'},
-                      {'value': 'UF_Col'},
-                      {'value': 'XAD'},
-                      {'value': 'U'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000020'} })
-    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'No pretreatment'},
-                      {'value': 'Samples were pretreated following Brock et al. '
-                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
-                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
-                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
-                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
-                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
-                      {'value': 'A dremel drill was used to remove visibly altered '
-                                'shell leaving dense translucent carbonate;  Charcoal '
-                                'was treated with HCl, NaOH and HCl.'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000021'} })
-    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
-                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
-                      {'value': 'PMID:35677847'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000022'} })
-    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
-         'slot_group': 'Method',
-         'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in mg.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000024'} })
-    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in mg""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '22'}, {'value': '2.3'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000025'} })
-    pretreatment_percentage_yield: Optional[float] = Field(default=None, title="Percentage yield after pretreatment", description="""Ratio of weight after pretreatment to sample starting weight""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '012'},
-                      {'value': '0.61'},
-                      {'value': '0.015'},
-                      {'value': '0.002'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000026'} })
-    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000027'} })
-    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
-13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000028'} })
-    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
-Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': '0.1'}, {'value': '0.2'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000029'} })
-    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
-either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
-         'recommended': True,
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000030'} })
-    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
-should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000031'} })
-    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
-         'examples': [{'value': 'true'}, {'value': 'false'}],
-         'slot_group': 'Quality control',
-         'slot_uri': 'c14:000037'} })
-
-    @field_validator('lab_id')
-    def pattern_lab_id(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid lab_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid lab_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_ids')
-    def pattern_sample_ids(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_ids format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_ids format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_material')
-    def pattern_sample_material(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_material format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_material format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_id')
-    def pattern_sample_taxon_id(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_id format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_id format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_taxon_scientific_name')
-    def pattern_sample_taxon_scientific_name(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_anatomical_part')
-    def pattern_sample_anatomical_part(cls, v):
-        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_anatomical_part format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_anatomical_part format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('suspected_sample_contamination_description')
-    def pattern_suspected_sample_contamination_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('sample_location')
-    def pattern_sample_location(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid sample_location format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid sample_location format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_description')
-    def pattern_pretreatment_method_description(cls, v):
-        pattern=re.compile(r"")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_description format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_description format: {v}"
-            raise ValueError(err_msg)
-        return v
-
-    @field_validator('pretreatment_method_protocol')
-    def pattern_pretreatment_method_protocol(cls, v):
-        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
-        if isinstance(v, list):
-            for element in v:
-                if isinstance(element, str) and not pattern.match(element):
-                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
-                    raise ValueError(err_msg)
-        elif isinstance(v, str) and not pattern.match(v):
-            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
-            raise ValueError(err_msg)
-        return v
 
 
 class Extension(ConfiguredBaseModel):
@@ -4238,17 +1880,19 @@ without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml
                       {'value': '1415(a)'}],
          'slot_group': 'Identifier',
          'slot_uri': 'c14:000002'} })
-    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
 conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
 NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
 Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000005'} })
-    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
 normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
 Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000006'} })
     f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
@@ -4398,7 +2042,7 @@ and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['
          'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
          'slot_group': 'Method',
          'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000024'} })
@@ -4630,17 +2274,19 @@ without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml
                       {'value': '1415(a)'}],
          'slot_group': 'Identifier',
          'slot_uri': 'c14:000002'} })
-    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
 conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
 NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
 Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000005'} })
-    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
 normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
 Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
          'slot_group': 'Measurement',
          'slot_uri': 'c14:000006'} })
     f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
@@ -4790,7 +2436,1541 @@ and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['
          'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
          'slot_group': 'Method',
          'slot_uri': 'c14:000023'} })
-    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of  in measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class F14CRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
+    """
+    F14C value radiocarbon date of a proteinaceous sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateProteinaceousSample',
+         'from_schema': 'https://w3id.org/miaard/miaard-schema',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'F14C value radiocarbon date (proteinaceous)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Whether the radiocarbon date was calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confident in taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate 'true', if identification is unclear or
+uncertain specify 'false'.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of the geographic location from which the sample originated.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '3.2'}, {'value': '3.33'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000032'} })
+    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000033'} })
+    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.3'}, {'value': '0.12'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000034'} })
+    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000035'} })
+    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.4'}, {'value': '0.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000036'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class F14CRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
+    """
+    F14C value radiocarbon date of a carbonate sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:F14CRadiocarbonDateCarbonateSample',
+         'from_schema': 'https://w3id.org/miaard/miaard-schema',
+         'mixins': ['RadiocarbonDate'],
+         'title': 'F14C value radiocarbon date (carbonate)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: Optional[float] = Field(default=None, title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: Optional[float] = Field(default=None, title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Whether the radiocarbon date was calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confident in taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate 'true', if identification is unclear or
+uncertain specify 'false'.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of the geographic location from which the sample originated.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    recrystalisation: bool = Field(default=..., title="Evidence of recrystalisation", description="""Sample shows evidence of recrystalisation which should be accounted for during analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['CarbonateSample'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000037'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ConventionalAgeRadiocarbonDateProteinaceousSample(ProteinaceousSample, RadiocarbonDate):
+    """
+    Conventional age radiocarbon date of a proteinaceous sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateProteinaceousSample',
+         'from_schema': 'https://w3id.org/miaard/miaard-schema',
+         'mixins': ['RadiocarbonDate'],
+         'slot_usage': {'conventional_age': {'name': 'conventional_age',
+                                             'required': True},
+                        'conventional_age_error': {'name': 'conventional_age_error',
+                                                   'required': True}},
+         'title': 'Conventional age radiocarbon date (proteinaceous)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Whether the radiocarbon date was calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confident in taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate 'true', if identification is unclear or
+uncertain specify 'false'.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of the geographic location from which the sample originated.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000024'} })
+    pretreatment_yield: float = Field(default=..., title="Weight after pretreatment", description="""Amount of sample remaining after pretreatment in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '22'}, {'value': '2.3'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000025'} })
+    pretreatment_proportion_yield: Optional[float] = Field(default=None, title="Proportion yield after pretreatment", description="""Proportion of weight after pretreatment to sample starting weight represented as a value between 0 and 1.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '012'},
+                      {'value': '0.61'},
+                      {'value': '0.015'},
+                      {'value': '0.002'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000026'} })
+    carbon_proportion: float = Field(default=..., title="Carbon proportion", description="""Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
+expressed as a value between 0 and 1. Used as a quality control measurement.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.41'}, {'value': '0.12'}, {'value': '0.70'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000027'} })
+    delta_13_c: Optional[float] = Field(default=None, title="Delta 13C value", description="""The delta carbon-13 value of the sample (δ13C), which is the ratio of the stable isotope
+13C to 12C, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '-21.5'}, {'value': '-13.5'}, {'value': '1.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000028'} })
+    delta_13_c_error: Optional[float] = Field(default=None, title="Delta 13C error", description="""The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.1'}, {'value': '0.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000029'} })
+    delta_13_c_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C measurement method", description="""Which spectrophotometry method was used to measure the delta carbon-13 value,
+either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'IRMS'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000030'} })
+    suspected_reservoir_effect: bool = Field(default=..., title="Suspected reservoir effect", description="""Specify whether there is a suspected carbon reservoir effect that
+should be accounted for in analysis.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000031'} })
+    carbon_nitro_ratio: float = Field(default=..., title="Carbon to nitrogen ratio", description="""Atomic ratio of carbon to nitrogen. Used for quality control value in
+proteinaceous samples for radiocarbon dating.""", json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '3.2'}, {'value': '3.33'}],
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000032'} })
+    delta_15_n: Optional[float] = Field(default=None, title="Delta 15N value", description="""The delta nitrogen-15 value of the sample (δ15N), which is the ratio of the stable isotope
+15N to 14N, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '10.8'}, {'value': '5.1'}, {'value': '27.2'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000033'} })
+    delta_15_n_error: Optional[float] = Field(default=None, title="Delta 15N error", description="""The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.3'}, {'value': '0.12'}],
+         'recommended': True,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000034'} })
+    delta_34_s: Optional[float] = Field(default=None, title="Delta 34S value", description="""The delta sulfur-34 value of the sample (δ34S), which is the ratio of the stable isotope
+34S to 32S, expressed in per mil (‰) notation. Used as a quality control measurement.""", ge=-1000, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '18.4'}, {'value': '-5.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000035'} })
+    delta_34_s_error: Optional[float] = Field(default=None, title="Delta 34S error", description="""The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+Used as a quality control measurement.""", ge=0, le=1000, json_schema_extra = { "linkml_meta": {'domain_of': ['ProteinaceousSample'],
+         'examples': [{'value': '0.4'}, {'value': '0.2'}],
+         'recommended': False,
+         'slot_group': 'Quality control',
+         'slot_uri': 'c14:000036'} })
+
+    @field_validator('lab_id')
+    def pattern_lab_id(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid lab_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid lab_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_ids')
+    def pattern_sample_ids(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_ids format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_ids format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_material')
+    def pattern_sample_material(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_material format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_material format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_id')
+    def pattern_sample_taxon_id(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_id format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_id format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_taxon_scientific_name')
+    def pattern_sample_taxon_scientific_name(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_taxon_scientific_name format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_taxon_scientific_name format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_anatomical_part')
+    def pattern_sample_anatomical_part(cls, v):
+        pattern=re.compile(r"[a-zA-Z]{2,}:[a-zA-Z0-9]\d+")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_anatomical_part format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_anatomical_part format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('suspected_sample_contamination_description')
+    def pattern_suspected_sample_contamination_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid suspected_sample_contamination_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid suspected_sample_contamination_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('sample_location')
+    def pattern_sample_location(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid sample_location format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid sample_location format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_description')
+    def pattern_pretreatment_method_description(cls, v):
+        pattern=re.compile(r"")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_description format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_description format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+    @field_validator('pretreatment_method_protocol')
+    def pattern_pretreatment_method_protocol(cls, v):
+        pattern=re.compile(r"^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$")
+        if isinstance(v, list):
+            for element in v:
+                if isinstance(element, str) and not pattern.match(element):
+                    err_msg = f"Invalid pretreatment_method_protocol format: {element}"
+                    raise ValueError(err_msg)
+        elif isinstance(v, str) and not pattern.match(v):
+            err_msg = f"Invalid pretreatment_method_protocol format: {v}"
+            raise ValueError(err_msg)
+        return v
+
+
+class ConventionalAgeRadiocarbonDateCarbonateSample(CarbonateSample, RadiocarbonDate):
+    """
+    Conventional age radiocarbon date of a carbonate sample
+    """
+    linkml_meta: ClassVar[LinkMLMeta] = LinkMLMeta({'class_uri': 'c14:ConventionalAgeRadiocarbonDateCarbonateSample',
+         'from_schema': 'https://w3id.org/miaard/miaard-schema',
+         'mixins': ['RadiocarbonDate'],
+         'slot_usage': {'conventional_age': {'name': 'conventional_age',
+                                             'required': True},
+                        'conventional_age_error': {'name': 'conventional_age_error',
+                                                   'required': True}},
+         'title': 'Conventional age radiocarbon date (carbonate)'})
+
+    lab_code: LabCode = Field(default=..., title="Laboratory code designation", description="""Unique laboratory code designation of the institution that made the measurement.
+This is the prefix used for each determination ID. The prefix should be
+derived from: https://radiocarbon.webhost.uits.arizona.edu/laboratories.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'OxA'},
+                      {'value': 'CAMS'},
+                      {'value': 'Beta'},
+                      {'value': 'CN-XX'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000001'} })
+    lab_id: str = Field(default=..., title="Radiocarbon determination identifier", description="""The unique identifier associated with a specific radiocarbon determination,
+without the radiocarbon laboratory identifier.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '982744'},
+                      {'value': 'i238493'},
+                      {'value': '9800507B'},
+                      {'value': '-X-1045-13'},
+                      {'value': '1415(a)'}],
+         'slot_group': 'Identifier',
+         'slot_uri': 'c14:000002'} })
+    conventional_age: float = Field(default=..., title="Conventional radiocarbon age", description="""The uncalibrated age from the laboratory measurement. Also known as the
+conventional radiocarbon age (CRA). Should be a conventional 14C age (i.e., 14C year BP)
+NOT in AD/BC format. This is typically the 'raw' age reported by the radiocarbon lab, in
+Before Present (BP) notation.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '4500'}, {'value': '37330'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000005'} })
+    conventional_age_error: float = Field(default=..., title="Conventional radiocarbon age error", description="""The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
+normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '25'}, {'value': '620'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000006'} })
+    f14c: float = Field(default=..., title="F14C radiocarbon value", description="""The F14C value from the laboratory measurement, i.e. the fraction modern carbon.
+For older determinations, generally equivalent to \"percent modern\" (pMC, or pM) divided by 100.""", ge=0, le=1, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.83756'}, {'value': '0.5371'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000003'} })
+    f14c_error: float = Field(default=..., title="F14C radiocarbon error", description="""The 1-standard deviation uncertainty around the F14C (C14) measurement,
+normally indicated as a ± after the main value. Must be in the same format.
+Sometimes referred to as the \"error\" or \"sigma\" of the measurement.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00434'}, {'value': '0.023843'}],
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000004'} })
+    delta_13_c_calculation_method: Optional[Delta13CMeasurementMethod] = Field(default=None, title="Delta 13C age calculation method", description="""Whether the radiocarbon date was calculated with an AMS derived δ13C, an IRMS derived δ13C,
+an alternative δ13C measurement method or an assumed δ13C.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'},
+                      {'value': 'IRMS'},
+                      {'value': 'Assumed'},
+                      {'value': 'Other'}],
+         'recommended': True,
+         'slot_group': 'Measurement',
+         'slot_uri': 'c14:000007'} })
+    sample_ids: list[str] = Field(default=..., title="Sample identifiers", description="""Any identifier associated with the sample under measurement
+(e.g. sample collection ID, archive object accession, ICOM/CIDOC Museum ID).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'PES001'},
+                      {'value': 'PES001.B1010'},
+                      {'value': 'Des 207 d'},
+                      {'value': 'Grave 78'},
+                      {'value': 'Box 427; Exc. year 1926 (small)'},
+                      {'value': 'KrSp E1/2012/E1/3775'},
+                      {'value': 'Iceman'},
+                      {'value': 'Tumba XVIII'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000008'} })
+    sample_material: str = Field(default=..., title="Radiocarbon dating sample material", description="""Material of the sample used to extract carbon used for radiocarbon dating measurements.
+Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
+organic samples.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0002481'}, {'value': 'ENVO:01000560'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000009'} })
+    sample_taxon_id: list[str] = Field(default=..., title="Radiocarbon dating sample taxon", description="""A taxonomic ID of the organism from which the sample used to extract carbon used for
+radiocarbon measurement originated. The taxonomic ID should come from an established
+ontology or database.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'NCBITAXON:9606'},
+                      {'value': 'gbif:2441105'},
+                      {'value': 'bold.taxonomy:786175'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000010'} })
+    sample_taxon_id_confidence: bool = Field(default=..., title="Confident in taxon assignment", description="""Specify the level of confidence of an exact taxon identification.
+If secure identification, indicate 'true', if identification is unclear or
+uncertain specify 'false'.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000011'} })
+    sample_taxon_scientific_name: Optional[str] = Field(default=None, title="Scientific name of the sample taxon", description="""A scientific name of the taxon corresponding to the taxonomic ID, or when a
+taxonomic ID does not currently exist for the specific taxon.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'Mammathus primigenius'},
+                      {'value': 'cf Mammathus'},
+                      {'value': 'Homo sapiens sapiens'},
+                      {'value': 'Capra sp.'},
+                      {'value': 'Ulmus davidiana var. japonica'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000012'} })
+    sample_anatomical_part: Optional[str] = Field(default=None, title="Anatomical part from which the sample is derived", description="""Anatomical part from which the sample is derived.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'UBERON:0000981'},
+                      {'value': 'PO:0009010'},
+                      {'value': 'BTO:0001411'},
+                      {'value': 'UBERON:3010209'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000013'} })
+    suspected_sample_contamination: Optional[bool] = Field(default=None, title="Suspected sample contamination", description="""Specify whether the sample has suspected contamination that may influence measurement
+(organic glue, consolidant, rootlets, embalming solution, staining etc.).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'true'}, {'value': 'false'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000014'} })
+    suspected_sample_contamination_description: Optional[str] = Field(default=None, title="Suspected sample contamination description", description="""If a sample has a suspected contamination (suspected_sample_contamination), provide a short
+description of the contamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'glue'},
+                      {'value': 'organic glue made from horse'},
+                      {'value': 'staining'},
+                      {'value': 'bitumen'},
+                      {'value': 'rootlets'},
+                      {'value': 'Consolidant was applied to the skull to stabilise the '
+                                'bone.'},
+                      {'value': 'Sample was preserved in a embalming solution '
+                                'containing formaldehyde and alcohol.'}],
+         'recommended': False,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000015'} })
+    sample_location: Optional[str] = Field(default=None, title="Sample location", description="""Name of the geographic location from which the sample originated.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': ''}, {'value': ''}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000016'} })
+    decimal_latitude: Optional[float] = Field(default=None, title="Decimal latitude", description="""The geographic latitude (in decimal degrees, using the spatial reference system) of the geographic center of a dcterms:Location. Positive values are north
+of the Equator, negative values are south of it. Legal values lie between -90 and 90, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '51.34254'}, {'value': '51.75'}, {'value': '-13.163'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000017'} })
+    decimal_longitude: Optional[float] = Field(default=None, title="Decimal longitude", description="""The geographic longitude (in decimal degrees, using the spatial reference system) of the
+geographic center of a dcterms:Location. Positive values are east of the Greenwich Meridian,
+negative values are west of it. Legal values lie between -180 and 180, inclusive.""", ge=-90, le=90, json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '12.38067'}, {'value': '-1.24'}, {'value': '-72.545'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000018'} })
+    coordinate_precision: Optional[float] = Field(default=None, title="Coordinate precision", description="""A decimal representation of the precision of the coordinates given in the decimal_latitude
+and decimal_longitude.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': '0.00005'}, {'value': '0.001'}, {'value': '0.0001'}],
+         'recommended': True,
+         'slot_group': 'Sample',
+         'slot_uri': 'c14:000019'} })
+    pretreatment_methods: list[PretreatmentMethods] = Field(default=..., title="Radiocarbon pretreatment methods", description="""Specify the types of general pretreatment methods applied for decontamination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'ABA'},
+                      {'value': 'A'},
+                      {'value': 'BABA'},
+                      {'value': 'Col'},
+                      {'value': 'UF_Col'},
+                      {'value': 'XAD'},
+                      {'value': 'U'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000020'} })
+    pretreatment_method_description: str = Field(default=..., title="Radiocarbon pretreatment method description", description="""Description of specific pretreatment method used for decontamination of sample prior determination.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'No pretreatment'},
+                      {'value': 'Samples were pretreated following Brock et al. '
+                                '(2010). Briefly, bone was demineralised (0.5M HCl, '
+                                'overnight), washed in base (0.1M NaOH, 30 min, RT) '
+                                'and acid (0.5M HCl, 1 hour, RT) before gelatinisation '
+                                '(0.001M HCl, 20 hours, 70oC), filtration (Ezee(TM)) '
+                                'and ultrafiltration (Vivaspin(TM) 30 kDa MWCO)'},
+                      {'value': 'A dremel drill was used to remove visibly altered '
+                                'shell leaving dense translucent carbonate;  Charcoal '
+                                'was treated with HCl, NaOH and HCl.'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000021'} })
+    pretreatment_method_protocol: list[str] = Field(default=..., title="Radiocarbon pretreatment method protocol", description="""A DOI, URL, or PMID to a publication describing the specific method of pretreatment applied.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'https://doi.org/10.1017/S0033822200045069 '},
+                      {'value': 'https://sites.ps.uci.edu/kccams/wp-content/uploads/sites/28/2016/12/bone_protocol.pdf'},
+                      {'value': 'PMID:35677847'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000022'} })
+    measurement_method: RadiocarbonMeasurementMethod = Field(default=..., title="Radiocarbon measurement method", description="""Type of measurement method the determination was made by.""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
+         'examples': [{'value': 'AMS'}, {'value': 'Conventional'}, {'value': 'PIMS'}],
+         'slot_group': 'Method',
+         'slot_uri': 'c14:000023'} })
+    sample_starting_weight: float = Field(default=..., title="Sample starting weight", description="""Amount of sample material used at beginning of measurement in miligrams (mg).""", json_schema_extra = { "linkml_meta": {'domain_of': ['RadiocarbonDate'],
          'examples': [{'value': '521'}, {'value': '56.7'}, {'value': '1'}],
          'slot_group': 'Quality control',
          'slot_uri': 'c14:000024'} })

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -175,6 +175,78 @@ classes:
     mixins:
       - RadiocarbonDate
 
+  ConventionalAgeRadiocarbonDateProteinaceousSample:
+    description: Conventional age radiocarbon date of a proteinaceous sample
+    title: Conventional age radiocarbon date (proteinaceous)
+    is_a: ProteinaceousSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:ConventionalAgeRadiocarbonDateProteinaceousSample
+    slot_usage:
+      f14c:
+        required: false
+        recommended: true
+      f14c_error:
+        required: false
+        recommended: true
+      conventional_age:
+        required: true
+        recommended: true
+      conventional_age_error:
+        required: true
+        recommended: true
+
+  ConventionalAgeRadiocarbonDateCarbonateSample:
+    description: Conventional age radiocarbon date of a carbonate sample
+    title: Conventional age radiocarbon date (carbonate)
+    is_a: CarbonateSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:ConventionalAgeRadiocarbonDateCarbonateSample
+    slot_usage:
+      f14c:
+        required: false
+      f14c_error:
+        required: false
+      conventional_age:
+        required: true
+      conventional_age_error:
+        required: true
+
+  F14CRadiocarbonDateProteinaceousSample:
+    description: F14C value radiocarbon date of a proteinaceous sample
+    title: F14C value radiocarbon date (proteinaceous)
+    is_a: ProteinaceousSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:F14CRadiocarbonDateProteinaceousSample
+    slot_usage:
+      f14c:
+        required: true
+      f14c_error:
+        required: true
+      conventional_age:
+        required: false
+      conventional_age_error:
+        required: false
+
+  F14CRadiocarbonDateCarbonateSample:
+    description: F14C value radiocarbon date of a carbonate sample
+    title: F14C value radiocarbon date (carbonate)
+    is_a: CarbonateSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:F14CRadiocarbonDateCarbonateSample
+    slot_usage:
+      f14c:
+        required: true
+      f14c_error:
+        required: true
+      conventional_age:
+        required: false
+      conventional_age_error:
+        required: false
+
 slots:
   lab_code:
     title: Laboratory code designation
@@ -222,7 +294,7 @@ slots:
     slot_uri: c14:000005
     multivalued: false
     range: float
-    required: true
+    required: false
     slot_group: "Measurement"
   conventional_age_error:
     title: Conventional radiocarbon age error
@@ -236,7 +308,8 @@ slots:
     slot_uri: c14:000006
     multivalued: false
     range: float
-    required: true
+    required: false
+    recommended: true
     slot_group: "Measurement"
   f14c:
     title:
@@ -251,7 +324,8 @@ slots:
     range: float
     minimum_value: 0
     maximum_value: 1
-    required: true
+    required: false
+    recommended: true
     slot_group: "Measurement"
   f14c_error:
     title: F14C radiocarbon error
@@ -265,7 +339,8 @@ slots:
     slot_uri: c14:000004
     multivalued: false
     range: float
-    required: true
+    required: false
+    recommended: true
     slot_group: "Measurement"
   delta_13_c_calculation_method:
     title: Delta 13C age calculation method

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -120,6 +120,22 @@ classes:
     mixins:
       - RadiocarbonDate
 
+  F14CRadiocarbonDateProteinaceousSample:
+    description: F14C value radiocarbon date of a proteinaceous sample
+    title: F14C value radiocarbon date (proteinaceous)
+    is_a: ProteinaceousSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:F14CRadiocarbonDateProteinaceousSample
+
+  F14CRadiocarbonDateCarbonateSample:
+    description: F14C value radiocarbon date of a carbonate sample
+    title: F14C value radiocarbon date (carbonate)
+    is_a: CarbonateSample
+    mixins:
+      - RadiocarbonDate
+    class_uri: c14:F14CRadiocarbonDateCarbonateSample
+
   ConventionalAgeRadiocarbonDateProteinaceousSample:
     description: Conventional age radiocarbon date of a proteinaceous sample
     title: Conventional age radiocarbon date (proteinaceous)
@@ -128,18 +144,10 @@ classes:
       - RadiocarbonDate
     class_uri: c14:ConventionalAgeRadiocarbonDateProteinaceousSample
     slot_usage:
-      f14c:
-        required: false
-        recommended: true
-      f14c_error:
-        required: false
-        recommended: true
       conventional_age:
         required: true
-        recommended: true
       conventional_age_error:
         required: true
-        recommended: true
 
   ConventionalAgeRadiocarbonDateCarbonateSample:
     description: Conventional age radiocarbon date of a carbonate sample
@@ -149,58 +157,10 @@ classes:
       - RadiocarbonDate
     class_uri: c14:ConventionalAgeRadiocarbonDateCarbonateSample
     slot_usage:
-      f14c:
-        required: false
-        recommended: true
-      f14c_error:
-        required: false
-        recommended: true
       conventional_age:
         required: true
-        recommended: true
       conventional_age_error:
         required: true
-        recommended: true
-
-  F14CRadiocarbonDateProteinaceousSample:
-    description: F14C value radiocarbon date of a proteinaceous sample
-    title: F14C value radiocarbon date (proteinaceous)
-    is_a: ProteinaceousSample
-    mixins:
-      - RadiocarbonDate
-    class_uri: c14:F14CRadiocarbonDateProteinaceousSample
-    slot_usage:
-      f14c:
-        required: true
-        recommended: true
-      f14c_error:
-        required: true
-        recommended: true
-      conventional_age:
-        required: false
-        recommended: true
-      conventional_age_error:
-        required: false
-        recommended: true
-
-  F14CRadiocarbonDateCarbonateSample:
-    description: F14C value radiocarbon date of a carbonate sample
-    title: F14C value radiocarbon date (carbonate)
-    is_a: CarbonateSample
-    mixins:
-      - RadiocarbonDate
-    class_uri: c14:F14CRadiocarbonDateCarbonateSample
-    slot_usage:
-      f14c:
-        required: true
-        recommended: true
-      f14c_error:
-        required: true
-        recommended: true
-      conventional_age:
-        required: false
-      conventional_age_error:
-        required: false
 
 slots:
   lab_code:
@@ -249,7 +209,6 @@ slots:
     slot_uri: c14:000005
     multivalued: false
     range: float
-    required: false
     recommended: true
     slot_group: "Measurement"
   conventional_age_error:
@@ -280,8 +239,7 @@ slots:
     range: float
     minimum_value: 0
     maximum_value: 1
-    required: false
-    recommended: true
+    required: true
     slot_group: "Measurement"
   f14c_error:
     title: F14C radiocarbon error
@@ -295,8 +253,7 @@ slots:
     slot_uri: c14:000004
     multivalued: false
     range: float
-    required: false
-    recommended: true
+    required: true
     slot_group: "Measurement"
   delta_13_c_calculation_method:
     title: Delta 13C age calculation method

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -206,12 +206,16 @@ classes:
     slot_usage:
       f14c:
         required: false
+        recommended: true
       f14c_error:
         required: false
+        recommended: true
       conventional_age:
         required: true
+        recommended: true
       conventional_age_error:
         required: true
+        recommended: true
 
   F14CRadiocarbonDateProteinaceousSample:
     description: F14C value radiocarbon date of a proteinaceous sample
@@ -223,12 +227,16 @@ classes:
     slot_usage:
       f14c:
         required: true
+        recommended: true
       f14c_error:
         required: true
+        recommended: true
       conventional_age:
         required: false
+        recommended: true
       conventional_age_error:
         required: false
+        recommended: true
 
   F14CRadiocarbonDateCarbonateSample:
     description: F14C value radiocarbon date of a carbonate sample
@@ -240,8 +248,10 @@ classes:
     slot_usage:
       f14c:
         required: true
+        recommended: true
       f14c_error:
         required: true
+        recommended: true
       conventional_age:
         required: false
       conventional_age_error:
@@ -295,6 +305,7 @@ slots:
     multivalued: false
     range: float
     required: false
+    recommended: true
     slot_group: "Measurement"
   conventional_age_error:
     title: Conventional radiocarbon age error

--- a/tests/data/invalid/RadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/invalid/RadiocarbonDateCarbonateSample-001.yaml
@@ -1,7 +1,7 @@
 # Example data object
 ## Problem: carbonate data has proteinaceous sample-specific fields (carbon_nitro_ratio)
 ---
-lab_code: "MAMS"
+lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
 conventional_age_error: 19

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
@@ -1,0 +1,24 @@
+# Example data object
+---
+lab_code: mams
+lab_id: "81038"
+conventional_age: 4468
+conventional_age_error: 19
+sample_ids:
+  - "PZN009.A"
+sample_material: "tooth"
+sample_taxon_id:
+  - "9606"
+sample_taxon_id_confidence: true
+pretreatment_methods:
+  - "UF_Col"
+pretreatment_method_description: >-
+  "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
+pretreatment_method_protocol:
+  - "doi:10.1016/j.nimb.2012.01.015"
+measurement_method: "AMS"
+sample_starting_weight: 487.4
+pretreatment_yield: 12
+carbon_proportion: 0.11
+suspected_reservoir_effect: false
+recrystalisation: false

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
@@ -2,20 +2,22 @@
 ---
 lab_code: mams
 lab_id: "81038"
+f14c: 0.573350252170459
+f14c_error: 0.00137336054487434
 conventional_age: 4468
 conventional_age_error: 19
 sample_ids:
   - "PZN009.A"
-sample_material: "tooth"
+sample_material: "UBERON:0002481"
 sample_taxon_id:
-  - "9606"
+  - "NCBITAXON:9606"
 sample_taxon_id_confidence: true
 pretreatment_methods:
   - "UF_Col"
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
@@ -1,0 +1,26 @@
+# Example data object
+---
+lab_code: mams
+lab_id: "81038"
+conventional_age: 4468
+conventional_age_error: 19
+sample_ids:
+  - "PZN009.A"
+sample_material: "tooth"
+sample_taxon_id:
+  - "9606"
+sample_taxon_id_confidence: true
+pretreatment_methods:
+  - "UF_Col"
+pretreatment_method_description: >-
+  "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
+pretreatment_method_protocol:
+  - "doi:10.1016/j.nimb.2012.01.015"
+measurement_method: "AMS"
+sample_starting_weight: 487.4
+pretreatment_yield: 12
+carbon_proportion: 0.11
+delta_13_c: -19.5331873576806
+delta_13_c_error: 0
+suspected_reservoir_effect: false
+carbon_nitro_ratio: 3.23198101920019

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
@@ -2,20 +2,22 @@
 ---
 lab_code: mams
 lab_id: "81038"
+f14c: 0.573350252170459
+f14c_error: 0.00137336054487434
 conventional_age: 4468
 conventional_age_error: 19
 sample_ids:
   - "PZN009.A"
-sample_material: "tooth"
+sample_material: "UBERON:0002481"
 sample_taxon_id:
-  - "9606"
+  - "NCBITAXON:9606"
 sample_taxon_id_confidence: true
 pretreatment_methods:
   - "UF_Col"
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
@@ -6,16 +6,16 @@ f14c: 0.573350252170459
 f14c_error: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
-sample_material: "tooth"
+sample_material: "UBERON:0002481"
 sample_taxon_id:
-  - "9606"
+  - "NCBITAXON:9606"
 sample_taxon_id_confidence: true
 pretreatment_methods:
   - "UF_Col"
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
@@ -1,0 +1,24 @@
+# Example data object
+---
+lab_code: mams
+lab_id: "81038"
+f14c: 0.573350252170459
+f14c_error: 0.00137336054487434
+sample_ids:
+  - "PZN009.A"
+sample_material: "tooth"
+sample_taxon_id:
+  - "9606"
+sample_taxon_id_confidence: true
+pretreatment_methods:
+  - "UF_Col"
+pretreatment_method_description: >-
+  "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
+pretreatment_method_protocol:
+  - "doi:10.1016/j.nimb.2012.01.015"
+measurement_method: "AMS"
+sample_starting_weight: 487.4
+pretreatment_yield: 12
+carbon_proportion: 0.11
+suspected_reservoir_effect: false
+recrystalisation: false

--- a/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
@@ -6,16 +6,16 @@ f14c: 0.573350252170459
 f14c_error: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
-sample_material: "tooth"
+sample_material: "UBERON:0002481"
 sample_taxon_id:
-  - "9606"
+  - "NCBITAXON:9606"
 sample_taxon_id_confidence: true
 pretreatment_methods:
   - "UF_Col"
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
@@ -1,0 +1,26 @@
+# Example data object
+---
+lab_code: mams
+lab_id: "81038"
+f14c: 0.573350252170459
+f14c_error: 0.00137336054487434
+sample_ids:
+  - "PZN009.A"
+sample_material: "tooth"
+sample_taxon_id:
+  - "9606"
+sample_taxon_id_confidence: true
+pretreatment_methods:
+  - "UF_Col"
+pretreatment_method_description: >-
+  "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
+pretreatment_method_protocol:
+  - "doi:10.1016/j.nimb.2012.01.015"
+measurement_method: "AMS"
+sample_starting_weight: 487.4
+pretreatment_yield: 12
+carbon_proportion: 0.11
+delta_13_c: -19.5331873576806
+delta_13_c_error: 0
+suspected_reservoir_effect: false
+carbon_nitro_ratio: 3.23198101920019

--- a/tests/data/valid/RadiocarbonDate-001.yaml
+++ b/tests/data/valid/RadiocarbonDate-001.yaml
@@ -17,7 +17,7 @@ pretreatment_methods:
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "https://doi.org/doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/RadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/RadiocarbonDateCarbonateSample-001.yaml
@@ -17,7 +17,7 @@ pretreatment_methods:
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "https://doi.org.10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12

--- a/tests/data/valid/RadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/RadiocarbonDateProteinaceousSample-001.yaml
@@ -17,7 +17,7 @@ pretreatment_methods:
 pretreatment_method_description: >-
   "Collagen is extracted from the bone samples (modified Longin method), purified by ultrafiltration (fraction >30kD) and freeze-dried."
 pretreatment_method_protocol:
-  - "https://doi.org/doi:10.1016/j.nimb.2012.01.015"
+  - "https://doi.org/10.1016/j.nimb.2012.01.015"
 measurement_method: "AMS"
 sample_starting_weight: 487.4
 pretreatment_yield: 12


### PR DESCRIPTION
## Contents

This adds new 'combination' classes of the core radiocarbon terms plus proteinaceoius/carbonate sample types to include also conventional age (pre-bomb) and F14C variant (pre-bomb)

## Query

> [!WARNING]
> Note this includes a breaking change: making the _core_ terms' of `conventional_age` and `F14C` _recommended_ only.

This is because I learned of the following, when checking the documentation of LinkML's `slot_usage` [^1]:

> Note that LinkML schemas are [monotonic](https://en.wikipedia.org/wiki/Monotonicity_of_entailment). This means it’s not possible to override existing constraints, new constraints are always additive and “layered on”.

Therefore it seems we can't 'relax' only make more strict.

**This may not be the behaviour we want**, as the core terms should be the minimal 'default', and in this case we want to _require_ one or the other.  

I feel we have three options here:

1. See if DataHarmonizer accepts the 'rules:' LinkML syntax (https://linkml.io/linkml/howtos/skip-logic.html#pattern-2-making-a-field-conditionally-required)
    - This again though is questionable as DataHarmonizer is only our 'helper' tool, not a required use of our standard 
2. _Always_ require `f14c`, but also require `conventional_age` when dealing with pre-bomb samples
3. Switch to Andrew's suggestion of a single term for the value `radiocarbon_value` and `value_type` Enum term of conventional or F14C

Your input here @joeroe would be very useful!

[^1]: https://linkml.io/linkml/schemas/slots.html#slot-usage