### PR TITLE
Propose (partial) feedback from Lorena

### DIFF
--- a/docs/schema/c14.yaml
+++ b/docs/schema/c14.yaml
@@ -1513,9 +1513,9 @@ slots:
     multivalued: false
     minimum_value: 0
     maximum_value: 1
-  f14c_error:
-    name: f14c_error
-    definition_uri: https://w3id.org/miaard/miaard-schema/f14c_error
+  f14c_uncertainty:
+    name: f14c_uncertainty
+    definition_uri: https://w3id.org/miaard/miaard-schema/f14c_uncertainty
     description:
       "The 1-standard deviation uncertainty around the F14C (C14) measurement,\n\
       normally indicated as a \xB1 after the main value. Must be in the same format.\n\
@@ -1566,9 +1566,9 @@ slots:
     range: float
     required: true
     multivalued: false
-  conventional_age_error:
-    name: conventional_age_error
-    definition_uri: https://w3id.org/miaard/miaard-schema/conventional_age_error
+  conventional_age_uncertainty:
+    name: conventional_age_uncertainty
+    definition_uri: https://w3id.org/miaard/miaard-schema/conventional_age_uncertainty
     description:
       "The 1-standard deviation around the conventional radiocarbon age\
       \ (C14) measurement,\nnormally indicated as a \xB1 after the main age. Must\
@@ -2179,9 +2179,9 @@ slots:
     multivalued: false
     minimum_value: -1000
     maximum_value: 1000
-  delta_13_c_error:
-    name: delta_13_c_error
-    definition_uri: https://w3id.org/miaard/miaard-schema/delta_13_c_error
+  delta_13_c_uncertainty:
+    name: delta_13_c_uncertainty
+    definition_uri: https://w3id.org/miaard/miaard-schema/delta_13_c_uncertainty
     description:
       "The error associated with the delta carbon-13 (\u03B413C) value\
       \ expressed (\u2030) notation.\nUsed as a quality control measurement."
@@ -2304,9 +2304,9 @@ slots:
     multivalued: false
     minimum_value: -1000
     maximum_value: 1000
-  delta_15_n_error:
-    name: delta_15_n_error
-    definition_uri: https://w3id.org/miaard/miaard-schema/delta_15_n_error
+  delta_15_n_uncertainty:
+    name: delta_15_n_uncertainty
+    definition_uri: https://w3id.org/miaard/miaard-schema/delta_15_n_uncertainty
     description:
       "The error associated with the delta nitrogen-15 (\u03B415N) value\
       \ expressed (\u2030) notation.\nUsed as a quality control measurement."
@@ -2355,9 +2355,9 @@ slots:
     multivalued: false
     minimum_value: -1000
     maximum_value: 1000
-  delta_34_s_error:
-    name: delta_34_s_error
-    definition_uri: https://w3id.org/miaard/miaard-schema/delta_34_s_error
+  delta_34_s_uncertainty:
+    name: delta_34_s_uncertainty
+    definition_uri: https://w3id.org/miaard/miaard-schema/delta_34_s_uncertainty
     description:
       "The error associated with the delta sulfur-34 (\u03B434S) value\
       \ expressed (\u2030) notation.\nUsed as a quality control measurement."
@@ -2425,9 +2425,9 @@ classes:
       - lab_code
       - lab_id
       - f14c
-      - f14c_error
+      - f14c_uncertainty
       - conventional_age
-      - conventional_age_error
+      - conventional_age_uncertainty
       - delta_13_c_calculation_method
       - sample_ids
       - sample_material
@@ -2450,7 +2450,7 @@ classes:
       - pretreatment_proportion_yield
       - carbon_proportion
       - delta_13_c
-      - delta_13_c_error
+      - delta_13_c_uncertainty
       - delta_13_c_method
       - suspected_reservoir_effect
     class_uri: c14:RadiocarbonDate
@@ -2481,9 +2481,9 @@ classes:
     slots:
       - carbon_nitro_ratio
       - delta_15_n
-      - delta_15_n_error
+      - delta_15_n_uncertainty
       - delta_34_s
-      - delta_34_s_error
+      - delta_34_s_uncertainty
     class_uri: c14:ProteinaceousSample
   CarbonateSample:
     name: CarbonateSample

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -46,6 +46,7 @@ classes:
       - f14c_uncertainty
       - delta_13_c_calculation_method
       - sample_ids
+      - sample_object
       - sample_material
       - sample_taxon_id
       - sample_taxon_id_confidence
@@ -291,15 +292,30 @@ slots:
     pattern: ""
     required: true
     slot_group: "Sample"
-  sample_material:
-    title: Radiocarbon dating sample material
+  sample_object:
+    title: Object submitted for dating
     examples:
-      - value: "UBERON:0002481"
+      - value: "UBERON:0003267"
       - value: "ENVO:01000560"
     description: |-
-      Material of the sample used to extract carbon used for radiocarbon dating measurements.
-      Use ontology terms where possible, e.g. from UBERON for anatomical parts, or ENVO for other
-      organic samples.
+      The type of object that was submitted for radiocarbon dating.
+      This should be a 'countable' object, such as a bone, shell, or piece of wood.
+      Use ontology terms where possible. For example, terms from UBERON for anatomical parts, or ENVO for other organic samples.
+    slot_uri: c14:000038
+    multivalued: false
+    range: string
+    pattern: "[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+"
+    recommended: true
+    slot_group: "Sample"
+  sample_material:
+    title: Material used for dating
+    examples:
+      - value: "UBERON:0002481"
+      - value: "PO:0025034"
+    description: |-
+      The material or substance of the sample used to extract carbon used for radiocarbon dating measurements.
+      This should be an substance that cannot be counted, such as collagen, cellulose, or mineral.
+      Use ontology terms where possible, For example, terms from UBERON for anatomical parts, or ENVO for other organic samples.
     slot_uri: c14:000009
     multivalued: false
     range: string

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -41,9 +41,9 @@ classes:
       - lab_code
       - lab_id
       - conventional_age
-      - conventional_age_error
+      - conventional_age_uncertainty
       - f14c
-      - f14c_error
+      - f14c_uncertainty
       - delta_13_c_calculation_method
       - sample_ids
       - sample_material
@@ -66,7 +66,7 @@ classes:
       - pretreatment_proportion_yield
       - carbon_proportion
       - delta_13_c
-      - delta_13_c_error
+      - delta_13_c_uncertainty
       - delta_13_c_method
       - suspected_reservoir_effect
 
@@ -93,9 +93,9 @@ classes:
       - nitrogen_proportion # Proteinaceous module
       - carbon_nitro_ratio # Proteinaceous module
       - delta_15_n # Proteinaceous module
-      - delta_15_n_error # Proteinaceous module
+      - delta_15_n_uncertainty # Proteinaceous module
       - delta_34_s # Proteinaceous module
-      - delta_34_s_error # Proteinaceous module
+      - delta_34_s_uncertainty # Proteinaceous module
 
   CarbonateSample:
     description: Terms specific to carbonate samples being dated.
@@ -147,7 +147,7 @@ classes:
     slot_usage:
       conventional_age:
         required: true
-      conventional_age_error:
+      conventional_age_uncertainty:
         required: true
 
   ConventionalAgeRadiocarbonDateCarbonateSample:
@@ -160,7 +160,7 @@ classes:
     slot_usage:
       conventional_age:
         required: true
-      conventional_age_error:
+      conventional_age_uncertainty:
         required: true
 
 slots:
@@ -212,15 +212,15 @@ slots:
     range: float
     recommended: true
     slot_group: "Measurement"
-  conventional_age_error:
-    title: Conventional radiocarbon age error
+  conventional_age_uncertainty:
+    title: Conventional radiocarbon age uncertainty
     examples:
       - value: "25"
       - value: "620"
     description: |-
       The 1-standard deviation around the conventional radiocarbon age (C14) measurement,
       normally indicated as a ± after the main age. Must be in the same format (i.e. 14C yr BP).
-      Sometimes referred to as the "error" or "sigma" of the measurement.
+      Sometimes referred to as the "uncertainty" or "sigma" of the measurement.
     slot_uri: c14:000006
     multivalued: false
     range: float
@@ -241,15 +241,15 @@ slots:
     minimum_value: 0
     required: true
     slot_group: "Measurement"
-  f14c_error:
-    title: F14C radiocarbon error
+  f14c_uncertainty:
+    title: F14C radiocarbon uncertainty
     examples:
       - value: "0.00434"
       - value: "0.023843"
     description: |-
       The 1-standard deviation uncertainty around the F14C (C14) measurement,
       normally indicated as a ± after the main value. Must be in the same format.
-      Sometimes referred to as the "error" or "sigma" of the measurement.
+      Sometimes referred to as the "uncertainty", "error," or "sigma" of the measurement.
     slot_uri: c14:000004
     multivalued: false
     range: float
@@ -615,13 +615,13 @@ slots:
     required: false
     recommended: true
     slot_group: "Quality control"
-  delta_13_c_error:
-    title: Delta 13C error
+  delta_13_c_uncertainty:
+    title: Delta 13C uncertainty
     examples:
       - value: "0.1"
       - value: "0.2"
     description: |-
-      The error associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
+      The uncertainty associated with the delta carbon-13 (δ13C) value expressed (‰) notation.
       Used as a quality control measurement.
     slot_uri: c14:000029
     multivalued: false
@@ -688,13 +688,13 @@ slots:
     required: false
     recommended: true
     slot_group: "Quality control"
-  delta_15_n_error:
-    title: Delta 15N error
+  delta_15_n_uncertainty:
+    title: Delta 15N uncertainty
     examples:
       - value: "0.3"
       - value: "0.12"
     description: |-
-      The error associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
+      The uncertainty associated with the delta nitrogen-15 (δ15N) value expressed (‰) notation.
       Used as a quality control measurement.
     slot_uri: c14:000034
     multivalued: false
@@ -720,13 +720,13 @@ slots:
     required: false
     recommended: false
     slot_group: "Quality control"
-  delta_34_s_error:
-    title: Delta 34S error
+  delta_34_s_uncertainty:
+    title: Delta 34S uncertainty
     examples:
       - value: "0.4"
       - value: "0.2"
     description: |-
-      The error associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
+      The uncertainty associated with the delta sulfur-34 (δ34S) value expressed (‰) notation.
       Used as a quality control measurement.
     slot_uri: c14:000036
     multivalued: false

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -106,6 +106,9 @@ classes:
     class_uri: c14:CarbonateSample
     slots:
       - recrystalisation # Carbonate module
+      - secondary_carbonate_assessed # Carbonate module
+      - secondary_carbonate_detected # Carbonate module
+      - secondary_carbonate_detection_method # Carbonate module
 
   RadiocarbonDateProteinaceousSample:
     description: A radiocarbon determination on a proteinaceous sample.

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -536,7 +536,7 @@ slots:
     slot_uri: c14:000024
     multivalued: false
     range: float
-    required: true
+    recommended: true
     slot_group: "Quality control"
   pretreatment_yield:
     title: Weight after pretreatment
@@ -548,7 +548,7 @@ slots:
     slot_uri: c14:000025
     multivalued: false
     range: float
-    required: true
+    recommended: true
     slot_group: "Quality control"
   pretreatment_proportion_yield:
     title: Proportion yield after pretreatment
@@ -564,7 +564,6 @@ slots:
     range: float
     minimum_value: 0
     maximum_value: 1
-    required: false
     recommended: true
     slot_group: "Quality control"
   carbon_proportion:
@@ -574,14 +573,14 @@ slots:
       - value: "0.12"
       - value: "0.70"
     description: |-
-      Proportion of carbon in a non-proteinaceous sample used for dating (such as charcoal),
-      expressed as a value between 0 and 1. Used as a quality control measurement.
+      Proportion of carbon in the sample used for dating, expressed as a value between 0 and 1.
+      Used as a quality control measurement.
     slot_uri: c14:000027
     multivalued: false
     range: float
     minimum_value: 0
     maximum_value: 1
-    required: true
+    recommended: true
     slot_group: "Quality control"
   delta_13_c:
     title: Delta 13C value

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -22,6 +22,7 @@ imports:
   - enums/radiocarbon_measurement_methods
   - enums/delta13c_measurement_methods
   - enums/carbonate_detection_methods
+  - enums/reservoir_effect_types
 
 # STRUCTURED PATTERNS
 ## syntax: ^{PMID}|{DOI}|{URL}$: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
@@ -799,6 +800,19 @@ slots:
     slot_uri: c14:000041
     multivalued: false
     range: CarbonateDetectionMethod
+    required: false
+    recommended: false
+    slot_group: "Quality control"
+  suspected_reservoir_effect_type:
+    title: Suspected reservoir effect type
+    examples:
+      - value: "true"
+      - value: "false"
+    description: |-
+      If a suspected reservoir effect is present, specify the type of suspected reservoir effect (e.g. marine, freshwater, volcanic).
+    slot_uri: c14:000042
+    multivalued: false
+    range: ReservoirEffectType
     required: false
     recommended: false
     slot_group: "Quality control"

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -72,6 +72,7 @@ classes:
       - delta_13_c_uncertainty
       - delta_13_c_method
       - suspected_reservoir_effect
+      - suspected_reservoir_effect_type
 
   RadiocarbonDateCollection:
     tree_root: true

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -90,6 +90,7 @@ classes:
     is_a: Extension
     class_uri: c14:ProteinaceousSample
     slots:
+      - nitrogen_proportion # Proteinaceous module
       - carbon_nitro_ratio # Proteinaceous module
       - delta_15_n # Proteinaceous module
       - delta_15_n_error # Proteinaceous module
@@ -581,6 +582,21 @@ slots:
     minimum_value: 0
     maximum_value: 1
     recommended: true
+    slot_group: "Quality control"
+  nitrogen_proportion:
+    title: Nitrogen proportion
+    examples:
+      - value: "0.41"
+      - value: "0.12"
+      - value: "0.70"
+    description: |-
+      Proportion of nitrogen in proteinaceous samples used for dating, expressed as a value between 0 and 1.
+      Used as a quality control measurement.
+    slot_uri: c14:000027
+    multivalued: false
+    range: float
+    minimum_value: 0
+    maximum_value: 1
     slot_group: "Quality control"
   delta_13_c:
     title: Delta 13C value

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -623,7 +623,7 @@ slots:
       - value: "AMS"
       - value: "IRMS"
     description: |-
-      Which spectrophotometry method was used to measure the delta carbon-13 value,
+      Which spectrometry method was used to measure the delta carbon-13 value,
       either with Isotope Ratio Mass Spectrometer (IRMS) or Accelerated Mass Spectrometer (AMS).
     slot_uri: c14:000030
     multivalued: false

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -21,6 +21,7 @@ imports:
   - enums/pretreatment_methods
   - enums/radiocarbon_measurement_methods
   - enums/delta13c_measurement_methods
+  - enums/carbonate_detection_methods
 
 # STRUCTURED PATTERNS
 ## syntax: ^{PMID}|{DOI}|{URL}$: ^(PMID:\d+|https:\/\/doi\.org\/10\.\d{2,9}/.*|https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*))$
@@ -763,4 +764,38 @@ slots:
     multivalued: false
     range: boolean
     required: true
+    slot_group: "Quality control"
+  secondary_carbonate_assessed:
+    title: Secondary carbonate assessed
+    examples:
+      - value: "true"
+      - value: "false"
+    description: |-
+      whether the sample was assessed for the presence of secondary carbonate.
+    slot_uri: c14:000039
+    multivalued: false
+    range: boolean
+    required: false
+    recommended: false
+    slot_group: "Quality control"
+  secondary_carbonate_detected:
+    title: Secondary carbonate detected
+    description: |-
+      Whether secondary carbonate was detected in the sample.
+      This would normally only be completed when secondary carbonate was assessed.
+    slot_uri: c14:000040
+    multivalued: false
+    range: boolean
+    required: false
+    recommended: false
+    slot_group: "Quality control"
+  secondary_carbonate_detection_method:
+    title: Secondary carbonate detection method
+    description: |-
+      The analytical or observational method used to assess the sample for secondary carbonate.
+    slot_uri: c14:000041
+    multivalued: false
+    range: CarbonateDetectionMethod
+    required: false
+    recommended: false
     slot_group: "Quality control"

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -238,7 +238,6 @@ slots:
     multivalued: false
     range: float
     minimum_value: 0
-    maximum_value: 1
     required: true
     slot_group: "Measurement"
   f14c_error:

--- a/src/c14/schema/c14.yaml
+++ b/src/c14/schema/c14.yaml
@@ -448,8 +448,8 @@ slots:
     slot_uri: c14:000018
     multivalued: false
     range: float
-    minimum_value: -90
-    maximum_value: 90
+    minimum_value: -180
+    maximum_value: 180
     required: false
     recommended: true
     slot_group: "Sample"

--- a/src/c14/schema/enums/carbonate_detection_methods.yaml
+++ b/src/c14/schema/enums/carbonate_detection_methods.yaml
@@ -1,0 +1,32 @@
+id: https://w3id.org/miaard/miaard-schema/carbonate_detection_methods
+name: carbonate_detection_methods
+title: MIAARD carbonate detection methods
+description: |-
+  Enumeration of carbonate detection methods. Part of the MIAARD
+  standard.
+license: MIT
+see_also:
+  - https://miaard.github.io/miaard-schema
+
+prefixes:
+  c14: https://w3id.org/miaard/miaard-schema/
+
+default_prefix: c14
+
+enums:
+  CarbonateDetectionMethod:
+    description: >-
+      Which method was used to detect presence of carbonate.
+    permissible_values:
+      XRD:
+        description: X-ray diffraction
+      FTIR:
+        description: Fourier-transform infrared spectroscopy
+      Feigl staining:
+        description: Feigl staining
+      Optical microscopy:
+        description: Optical microscopy
+      Other:
+        description: Other method for detecting carbonate
+      Unknown:
+        description: Unknown detection method

--- a/src/c14/schema/enums/delta13c_measurement_methods.yaml
+++ b/src/c14/schema/enums/delta13c_measurement_methods.yaml
@@ -24,3 +24,7 @@ enums:
         description: Isotope Ratio Mass Spectrometer
       CRDS:
         description: Cavity Ring-Down Spectroscopy
+      Other:
+        description: Other method (e.g. mass spectrophotometry methods)
+      Unknown:
+        description: Unknown spectrometry method

--- a/src/c14/schema/enums/reservoir_effect_types.yaml
+++ b/src/c14/schema/enums/reservoir_effect_types.yaml
@@ -1,0 +1,32 @@
+id: https://w3id.org/miaard/miaard-schema/reservoir_effect_types
+name: reservoir_effect_types
+title: MIAARD reservoir effect types
+description: |-
+  Enumeration of reservoir effect types. Part of the MIAARD
+  standard.
+license: MIT
+see_also:
+  - https://miaard.github.io/miaard-schema
+
+prefixes:
+  c14: https://w3id.org/miaard/miaard-schema/
+
+default_prefix: c14
+
+enums:
+  ReservoirEffectType:
+    description: >-
+      Type of reservoir effect.
+    permissible_values:
+      Marine:
+        description: Marine reservoir effect
+      Freshwater:
+        description: Freshwater reservoir effect
+      Volcanic:
+        description: Volcanic reservoir effect
+      Geothermal:
+        description: Geothermal reservoir effect
+      Other:
+        description: Other reservoir effect
+      Unknown:
+        description: Unknown reservoir effect

--- a/tests/data/invalid/RadiocarbonDate-001.yaml
+++ b/tests/data/invalid/RadiocarbonDate-001.yaml
@@ -4,9 +4,9 @@
 lab_code: "MAMS81038"
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: -67515.61
-f14c_error: -23754.13
+f14c_uncertainty: -23754.13
 sample_ids:
   - "PZN009.A"
 sample_material: "tooth"
@@ -22,7 +22,7 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 11.6126384899467
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 carbon_nitro_ratio: 3.23198101920019
 recrystalisation: false

--- a/tests/data/invalid/RadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/invalid/RadiocarbonDateCarbonateSample-001.yaml
@@ -4,9 +4,9 @@
 lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "tooth"
@@ -24,6 +24,6 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 0.11
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 carbon_nitro_ratio: 3.23198101920019

--- a/tests/data/invalid/RadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/invalid/RadiocarbonDateProteinaceousSample-001.yaml
@@ -4,9 +4,9 @@
 lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "tooth"
@@ -24,6 +24,6 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 0.11
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 recrystalisation: true

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateCarbonateSample-001.yaml
@@ -3,9 +3,9 @@
 lab_code: mams
 lab_id: "81038"
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"

--- a/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/ConventionalAgeRadiocarbonDateProteinaceousSample-001.yaml
@@ -3,9 +3,9 @@
 lab_code: mams
 lab_id: "81038"
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"
@@ -23,6 +23,6 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 0.11
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 carbon_nitro_ratio: 3.23198101920019

--- a/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateCarbonateSample-001.yaml
@@ -3,7 +3,7 @@
 lab_code: mams
 lab_id: "81038"
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"

--- a/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/F14CRadiocarbonDateProteinaceousSample-001.yaml
@@ -3,7 +3,7 @@
 lab_code: mams
 lab_id: "81038"
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"
@@ -21,6 +21,6 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 0.11
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 carbon_nitro_ratio: 3.23198101920019

--- a/tests/data/valid/RadiocarbonDate-001.yaml
+++ b/tests/data/valid/RadiocarbonDate-001.yaml
@@ -3,9 +3,9 @@
 lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"

--- a/tests/data/valid/RadiocarbonDateCarbonateSample-001.yaml
+++ b/tests/data/valid/RadiocarbonDateCarbonateSample-001.yaml
@@ -3,9 +3,9 @@
 lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "ENVO:01000560"

--- a/tests/data/valid/RadiocarbonDateProteinaceousSample-001.yaml
+++ b/tests/data/valid/RadiocarbonDateProteinaceousSample-001.yaml
@@ -3,9 +3,9 @@
 lab_code: mams
 lab_id: "81038"
 conventional_age: 4468
-conventional_age_error: 19
+conventional_age_uncertainty: 19
 f14c: 0.573350252170459
-f14c_error: 0.00137336054487434
+f14c_uncertainty: 0.00137336054487434
 sample_ids:
   - "PZN009.A"
 sample_material: "UBERON:0002481"
@@ -23,6 +23,6 @@ sample_starting_weight: 487.4
 pretreatment_yield: 12
 carbon_proportion: 0.11
 delta_13_c: -19.5331873576806
-delta_13_c_error: 0
+delta_13_c_uncertainty: 0
 suspected_reservoir_effect: false
 carbon_nitro_ratio: 3.23198101920019


### PR DESCRIPTION
1. Refines the d13C method
2. Removes upper limit for `f14c`
3. Switch starting weight, pre-treatment yield, and carbon proportion to recommended rather than required (as even if helpful, apparently they not necessary to have a reliable 'date') -> however again we should consider if we should be stricter here anyway
4. Add additional `nitrogen_proportion` QC term for proteinaceous samples
5. Fixed copy-paste error in the longitude coordinates
6. Replace the word `error` with `uncertainty` throughout 
7. Adds new term: sample_object (to distinguish from sample_material)
8. Adds 3 new terms for carbonates: secondary carbonate asssesed, detected, and method
9. Adds new term: suspected reservoir effect type 